### PR TITLE
Introduce "controller init" and generate self-signed X.509 certificate

### DIFF
--- a/internal/command/controller/controller.go
+++ b/internal/command/controller/controller.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-var dataDir string
+var dataDirPath string
 
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -15,15 +15,15 @@ func NewCommand() *cobra.Command {
 		Short: "Initialize and run a controller on the local machine",
 	}
 
-	command.AddCommand(newRunCommand())
+	command.AddCommand(newInitCommand(), newRunCommand())
 
 	orchardHome, err := orchardhome.Path()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	command.PersistentFlags().StringVar(&dataDir, "data-dir", filepath.Join(orchardHome, "controller"),
-		"path to the data directory")
+	command.PersistentFlags().StringVar(&dataDirPath, "data-dir", filepath.Join(orchardHome, "controller"),
+		"path to the data controller's directory")
 
 	return command
 }

--- a/internal/command/controller/init.go
+++ b/internal/command/controller/init.go
@@ -1,0 +1,141 @@
+package controller
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"github.com/cirruslabs/orchard/internal/controller"
+	"github.com/spf13/cobra"
+	"math/big"
+	"time"
+)
+
+var ErrInitFailed = errors.New("controller initialization failed")
+
+var controllerCertPath string
+var controllerKeyPath string
+var force bool
+
+func newInitCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize the controller",
+		RunE:  runInit,
+	}
+
+	command.PersistentFlags().StringVar(&controllerCertPath, "controller-cert", "",
+		"do not auto-generate the controller certificate, import it from the specified path instead"+
+			" (requires --controller-key)")
+	command.PersistentFlags().StringVar(&controllerKeyPath, "controller-key", "",
+		"do not auto-generate the controller certificate key, import it from the specified path instead"+
+			" (requires --controller-cert)")
+	command.PersistentFlags().BoolVar(&force, "force", false,
+		"force re-initialization if the controller is already initialized")
+
+	return command
+}
+
+func runInit(cmd *cobra.Command, args []string) (err error) {
+	var controllerCert tls.Certificate
+
+	dataDir, err := controller.NewDataDir(dataDirPath)
+	if err != nil {
+		return err
+	}
+
+	initialized, err := dataDir.Initialized()
+	if err != nil {
+		return err
+	}
+
+	if initialized && !force {
+		return fmt.Errorf("%w: controller is already initialized, preventing overwrite; "+
+			"please specify \"--force\" to re-initialize", ErrInitFailed)
+	}
+
+	if controllerCertPath != "" || controllerKeyPath != "" {
+		if err := checkBothCertAndKeyAreSpecified(); err != nil {
+			return err
+		}
+
+		controllerCert, err = tls.LoadX509KeyPair(controllerCertPath, controllerCertPath)
+		if err != nil {
+			return err
+		}
+	} else {
+		controllerCert, err = generateSelfSignedControllerCertificate()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := dataDir.SetControllerCertificate(controllerCert); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkBothCertAndKeyAreSpecified() error {
+	if controllerCertPath == "" {
+		return fmt.Errorf("%w: when --controller-key is specified, --controller-cert must be specified too",
+			ErrInitFailed)
+	}
+
+	if controllerKeyPath == "" {
+		return fmt.Errorf("%w: when --controller-cert is specified, --controller-key must be specified too",
+			ErrInitFailed)
+	}
+
+	return nil
+}
+
+func generateSelfSignedControllerCertificate() (tls.Certificate, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), cryptorand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	now := time.Now()
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName: "Orchard Controller",
+		},
+		NotBefore:             now,
+		NotAfter:              now.AddDate(10, 0, 0),
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{"orchard-controller"},
+	}
+
+	certBytes, err := x509.CreateCertificate(cryptorand.Reader, cert, cert, privateKey.Public(), privateKey)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEMBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	privateKeyPEMBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+
+	return tls.X509KeyPair(certPEMBytes, privateKeyPEMBytes)
+}

--- a/internal/command/dev/dev.go
+++ b/internal/command/dev/dev.go
@@ -19,11 +19,6 @@ func NewCommand() *cobra.Command {
 }
 
 func runDev(cmd *cobra.Command, args []string) error {
-	tempDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return err
-	}
-
 	// Initialize the logger
 	logger, err := zap.NewDevelopment()
 	if err != nil {
@@ -35,12 +30,22 @@ func runDev(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	controller, err := controller.New(controller.WithDataDir(tempDir), controller.WithLogger(logger))
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
 
-	worker, err := worker.New(worker.WithDataDir(tempDir), worker.WithLogger(logger))
+	dataDir, err := controller.NewDataDir(tempDir)
+	if err != nil {
+		return err
+	}
+
+	controller, err := controller.New(controller.WithDataDir(dataDir), controller.WithLogger(logger))
+	if err != nil {
+		return err
+	}
+
+	worker, err := worker.New(worker.WithDataDirPath(tempDir), worker.WithLogger(logger))
 	if err != nil {
 		return err
 	}

--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -25,7 +25,7 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 		}
 	}()
 
-	worker, err := worker.New(worker.WithDataDir(dataDir), worker.WithLogger(logger))
+	worker, err := worker.New(worker.WithDataDirPath(dataDirPath), worker.WithLogger(logger))
 	if err != nil {
 		return err
 	}

--- a/internal/command/worker/worker.go
+++ b/internal/command/worker/worker.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-var dataDir string
+var dataDirPath string
 
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -22,8 +22,8 @@ func NewCommand() *cobra.Command {
 		log.Fatal(err)
 	}
 
-	command.PersistentFlags().StringVar(&dataDir, "data-dir", filepath.Join(orchardHome, "worker"),
-		"path to the data directory")
+	command.PersistentFlags().StringVar(&dataDirPath, "data-dir", filepath.Join(orchardHome, "worker"),
+		"path to the worker's data directory")
 
 	return command
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -15,7 +15,7 @@ import (
 var ErrInitFailed = errors.New("controller initialization failed")
 
 type Controller struct {
-	dataDir    string
+	dataDir    *DataDir
 	listenAddr string
 	tlsConfig  *tls.Config
 	listener   net.Listener
@@ -33,7 +33,7 @@ func New(opts ...Option) (*Controller, error) {
 	}
 
 	// Apply defaults
-	if controller.dataDir == "" {
+	if controller.dataDir == nil {
 		return nil, fmt.Errorf("%w: please specify the data directory path with WithDataDir()",
 			ErrInitFailed)
 	}
@@ -45,7 +45,7 @@ func New(opts ...Option) (*Controller, error) {
 	}
 
 	// Instantiate controller
-	store, err := storepkg.New(controller.dbPath())
+	store, err := storepkg.New(controller.dataDir.DBPath())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/datadir.go
+++ b/internal/controller/datadir.go
@@ -1,7 +1,93 @@
 package controller
 
-import "path/filepath"
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
 
-func (controller *Controller) dbPath() string {
-	return filepath.Join(controller.dataDir, "db")
+var ErrDataDirError = errors.New("controller's data directory operation error")
+
+type DataDir struct {
+	path string
+}
+
+func NewDataDir(path string) (*DataDir, error) {
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return nil, fmt.Errorf("%w: failed to create data directory at path %s: %v",
+			ErrDataDirError, path, err)
+	}
+
+	return &DataDir{
+		path: path,
+	}, nil
+}
+
+func (dataDir *DataDir) ControllerCertificate() (tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(dataDir.ControllerCertificatePath(), dataDir.ControllerKeyPath())
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("%w: failed to load controller's certificate and key: %v",
+			ErrDataDirError, err)
+	}
+
+	return cert, nil
+}
+
+func (dataDir *DataDir) SetControllerCertificate(certificate tls.Certificate) error {
+	certPEMBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certificate.Certificate[0],
+	})
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(certificate.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("%w: failed to set controller's certificate: PKCS #8 marshalling failed: %v",
+			ErrDataDirError, err)
+	}
+
+	privateKeyPEMBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+
+	err = os.WriteFile(dataDir.ControllerCertificatePath(), certPEMBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("%w: failed to write controller's certificate: %v", ErrDataDirError, err)
+	}
+	err = os.WriteFile(dataDir.ControllerKeyPath(), privateKeyPEMBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("%w: failed to write controller's key: %v", ErrDataDirError, err)
+	}
+
+	return nil
+}
+
+func (dataDir *DataDir) DBPath() string {
+	return filepath.Join(dataDir.path, "db")
+}
+
+func (dataDir *DataDir) ControllerCertificatePath() string {
+	return filepath.Join(dataDir.path, "controller.crt")
+}
+
+func (dataDir *DataDir) ControllerKeyPath() string {
+	return filepath.Join(dataDir.path, "controller.key")
+}
+
+func (dataDir *DataDir) Initialized() (bool, error) {
+	dataDirEntries, err := os.ReadDir(dataDir.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("%w: failed to read data directory contents at path %s: %v",
+			ErrDataDirError, dataDir.path, err)
+	}
+
+	return len(dataDirEntries) != 0, nil
 }

--- a/internal/controller/option.go
+++ b/internal/controller/option.go
@@ -7,7 +7,7 @@ import (
 
 type Option func(*Controller)
 
-func WithDataDir(dataDir string) Option {
+func WithDataDir(dataDir *DataDir) Option {
 	return func(controller *Controller) {
 		controller.dataDir = dataDir
 	}

--- a/internal/worker/option.go
+++ b/internal/worker/option.go
@@ -4,9 +4,9 @@ import "go.uber.org/zap"
 
 type Option func(*Worker)
 
-func WithDataDir(dataDir string) Option {
+func WithDataDirPath(dataDir string) Option {
 	return func(worker *Worker) {
-		worker.dataDir = dataDir
+		worker.dataDirPath = dataDir
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -17,12 +17,12 @@ const pollInterval = 5 * time.Second
 var ErrPollFailed = errors.New("failed to poll controller")
 
 type Worker struct {
-	dataDir string
-	name    string
-	uid     string
-	vmm     *vmmanager.VMManager
-	client  *client.Client
-	logger  *zap.SugaredLogger
+	dataDirPath string
+	name        string
+	uid         string
+	vmm         *vmmanager.VMManager
+	client      *client.Client
+	logger      *zap.SugaredLogger
 }
 
 func New(opts ...Option) (*Worker, error) {


### PR DESCRIPTION
Additionally allow passing a user-generated X.509 certificate to support cases like [AWS Private CA](https://docs.aws.amazon.com/privateca/index.html).

The client-side support of this TLS milestone will be added as a part of https://github.com/cirruslabs/orchard/issues/2 since it requires a storage for X.509 certificates received from the controller.

Resolves https://github.com/cirruslabs/orchard/issues/11.