### PR TITLE
Simplified bootstrapping of a cluster

### DIFF
--- a/internal/command/controller/init.go
+++ b/internal/command/controller/init.go
@@ -20,8 +20,6 @@ var ErrInitFailed = errors.New("controller initialization failed")
 
 var controllerCertPath string
 var controllerKeyPath string
-var serviceAccountName string
-var serviceAccountToken string
 
 func FindControllerCertificate(dataDir *controller.DataDir) (controllerCert tls.Certificate, err error) {
 	if controllerCertPath != "" || controllerKeyPath != "" {

--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -43,6 +43,9 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 		client.WithTrustedCertificate(bootstrapToken.Certificate()),
 		client.WithCredentials(bootstrapToken.ServiceAccountName(), bootstrapToken.ServiceAccountToken()),
 	)
+	if err != nil {
+		return err
+	}
 
 	// Initialize the logger
 	logger, err := zap.NewProduction()

--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -1,19 +1,49 @@
 package worker
 
 import (
+	"errors"
+	"github.com/cirruslabs/orchard/internal/bootstraptoken"
+	"github.com/cirruslabs/orchard/internal/netconstants"
 	"github.com/cirruslabs/orchard/internal/worker"
+	"github.com/cirruslabs/orchard/pkg/client"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
 
+var ErrBootstrapTokenNotProvided = errors.New("no bootstrap token provided")
+
+var bootstrapTokenRaw string
+
 func newRunCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:  "run",
 		RunE: runWorker,
+		Args: cobra.ExactArgs(1),
 	}
+	cmd.PersistentFlags().StringVar(&bootstrapTokenRaw, "bootstrap-token", "",
+		"a bootstrap token retrieved via `orchard get bootstrap-token <service-account-name-for-workers>`")
+	return cmd
 }
 
 func runWorker(cmd *cobra.Command, args []string) (err error) {
+	controllerURL, err := netconstants.NormalizeAddress(args[0])
+	if err != nil {
+		return err
+	}
+	if bootstrapTokenRaw == "" {
+		return ErrBootstrapTokenNotProvided
+	}
+	bootstrapToken, err := bootstraptoken.NewFromString(bootstrapTokenRaw)
+	if err != nil {
+		return err
+	}
+
+	controllerClient, err := client.New(
+		client.WithAddress(controllerURL.String()),
+		client.WithTrustedCertificate(bootstrapToken.Certificate()),
+		client.WithCredentials(bootstrapToken.ServiceAccountName(), bootstrapToken.ServiceAccountToken()),
+	)
+
 	// Initialize the logger
 	logger, err := zap.NewProduction()
 	if err != nil {
@@ -25,10 +55,10 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 		}
 	}()
 
-	worker, err := worker.New(worker.WithDataDirPath(dataDirPath), worker.WithLogger(logger))
+	workerInstance, err := worker.New(worker.WithClient(controllerClient), worker.WithLogger(logger))
 	if err != nil {
 		return err
 	}
 
-	return worker.Run(cmd.Context())
+	return workerInstance.Run(cmd.Context())
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -129,6 +129,12 @@ func (controller *Controller) EnsureServiceAccount(serviceAccount *v1.ServiceAcc
 	})
 }
 
+func (controller *Controller) DeleteServiceAccount(name string) error {
+	return controller.store.Update(func(txn storepkg.Transaction) error {
+		return txn.DeleteServiceAccount(name)
+	})
+}
+
 func (controller *Controller) Run(ctx context.Context) error {
 	// Run the scheduler so that each VM will eventually
 	// be assigned to a specific WorkerUID

--- a/internal/netconstants/netconstants.go
+++ b/internal/netconstants/netconstants.go
@@ -1,6 +1,28 @@
 package netconstants
 
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
 const (
 	DefaultControllerPort       = 6120
 	DefaultControllerServerName = "orchard-controller"
 )
+
+func NormalizeAddress(addr string) (*url.URL, error) {
+	if !strings.HasPrefix(addr, "https://") && !strings.HasPrefix(addr, "http://") {
+		addr = "https://" + addr
+	}
+
+	controllerURL, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if controllerURL.Port() == "" {
+		controllerURL.Host += fmt.Sprintf(":%d", DefaultControllerPort)
+	}
+	return controllerURL, nil
+}

--- a/internal/worker/option.go
+++ b/internal/worker/option.go
@@ -1,6 +1,9 @@
 package worker
 
-import "go.uber.org/zap"
+import (
+	"github.com/cirruslabs/orchard/pkg/client"
+	"go.uber.org/zap"
+)
 
 type Option func(*Worker)
 
@@ -13,5 +16,11 @@ func WithDataDirPath(dataDir string) Option {
 func WithLogger(logger *zap.Logger) Option {
 	return func(worker *Worker) {
 		worker.logger = logger.Sugar()
+	}
+}
+
+func WithClient(client *client.Client) Option {
+	return func(worker *Worker) {
+		worker.client = client
 	}
 }

--- a/pkg/client/option.go
+++ b/pkg/client/option.go
@@ -1,6 +1,10 @@
 package client
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/cirruslabs/orchard/internal/netconstants"
+)
 
 type Option func(*Client)
 
@@ -10,9 +14,17 @@ func WithAddress(address string) Option {
 	}
 }
 
-func WithTLSConfig(tlsConfig *tls.Config) Option {
+func WithTrustedCertificate(cert *x509.Certificate) Option {
 	return func(client *Client) {
-		client.tlsConfig = tlsConfig
+		// Check that the API is accessible
+		privatePool := x509.NewCertPool()
+		privatePool.AddCert(cert)
+
+		client.tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			RootCAs:    privatePool,
+			ServerName: netconstants.DefaultControllerServerName,
+		}
 	}
 }
 


### PR DESCRIPTION
Introduced a new convention about a pre-defined `bootstrap-admin` account for `orchard controller run`. Providing `ORCHARD_BOOTSTRAP_ADMIN_TOKEN` will auto-create such user for easier configuration. `bootstrap-admin` can be used for creating other service accounts on the first run and after that can be disposed.

Also change `orchard worker run` to expect controller URL as the only parameter and a bootstrap token passed via an argument instead of using a context that might not be created.