### PR TITLE
Always require a client for running a worker

### DIFF
--- a/internal/command/dev/dev.go
+++ b/internal/command/dev/dev.go
@@ -3,6 +3,7 @@ package dev
 import (
 	"github.com/cirruslabs/orchard/internal/controller"
 	"github.com/cirruslabs/orchard/internal/worker"
+	"github.com/cirruslabs/orchard/pkg/client"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"os"
@@ -80,7 +81,11 @@ func CreateDevControllerAndWorker(devDataDirPath string) (*controller.Controller
 		return nil, nil, err
 	}
 
-	devWorker, err := worker.New(worker.WithDataDirPath(devDataDirPath), worker.WithLogger(logger))
+	defaultClient, err := client.New()
+	if err != nil {
+		return nil, nil, err
+	}
+	devWorker, err := worker.New(defaultClient, worker.WithLogger(logger))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -59,7 +59,7 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 		}
 	}()
 
-	workerInstance, err := worker.New(worker.WithClient(controllerClient), worker.WithLogger(logger))
+	workerInstance, err := worker.New(controllerClient, worker.WithLogger(logger))
 	if err != nil {
 		return err
 	}

--- a/internal/worker/option.go
+++ b/internal/worker/option.go
@@ -1,26 +1,13 @@
 package worker
 
 import (
-	"github.com/cirruslabs/orchard/pkg/client"
 	"go.uber.org/zap"
 )
 
 type Option func(*Worker)
 
-func WithDataDirPath(dataDir string) Option {
-	return func(worker *Worker) {
-		worker.dataDirPath = dataDir
-	}
-}
-
 func WithLogger(logger *zap.Logger) Option {
 	return func(worker *Worker) {
 		worker.logger = logger.Sugar()
-	}
-}
-
-func WithClient(client *client.Client) Option {
-	return func(worker *Worker) {
-		worker.client = client
 	}
 }


### PR DESCRIPTION
Otherwise it's getting overriden by the default one