### PR TITLE
Tests: use separate controller listening ports to prevent conflicts

### DIFF
--- a/internal/command/dev/dev.go
+++ b/internal/command/dev/dev.go
@@ -78,6 +78,7 @@ func CreateDevControllerAndWorker(devDataDirPath string) (*controller.Controller
 
 	devController, err := controller.New(
 		controller.WithDataDir(dataDir),
+		controller.WithListenAddr(":0"),
 		controller.WithInsecureAuthDisabled(),
 		controller.WithLogger(logger),
 	)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -161,8 +161,11 @@ func (controller *Controller) Run(ctx context.Context) error {
 }
 
 func (controller *Controller) Address() string {
-	if strings.HasPrefix(controller.listenAddr, ":") {
-		return fmt.Sprintf("http://localhost%s", controller.listenAddr)
+	hostPort := strings.ReplaceAll(controller.listener.Addr().String(), "[::]", "127.0.0.1")
+
+	if controller.tlsConfig != nil {
+		return fmt.Sprintf("https://%s", hostPort)
 	}
-	return controller.listenAddr
+
+	return fmt.Sprintf("http://%s", hostPort)
 }

--- a/internal/tests/integration_test.go
+++ b/internal/tests/integration_test.go
@@ -175,7 +175,7 @@ func StartIntegrationTestEnvironment(t *testing.T) *client.Client {
 
 	time.Sleep(5 * time.Second)
 
-	devClient, err := client.New()
+	devClient, err := client.New(client.WithAddress(devController.Address()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Should resolve `Test (macOS)` failures.