### PR TITLE
Remove worker role

### DIFF
--- a/DeploymentGuide.md
+++ b/DeploymentGuide.md
@@ -64,7 +64,7 @@ orchard context default production
 ## Configuring Orchard Workers
 
 ```bash
-orchard create service-account worker-pool-m1 --roles "worker" --roles "compute:write" --roles "compute:read"
+orchard create service-account worker-pool-m1 --roles "compute:read" --roles "compute:write"
 orchard get bootstrap-token worker-pool-m1
 ```
 

--- a/internal/controller/api_workers.go
+++ b/internal/controller/api_workers.go
@@ -11,8 +11,7 @@ import (
 )
 
 func (controller *Controller) createWorker(ctx *gin.Context) responder.Responder {
-	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeWrite,
-		v1.ServiceAccountRoleWorker); responder != nil {
+	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeWrite); responder != nil {
 		return responder
 	}
 
@@ -55,8 +54,7 @@ func (controller *Controller) createWorker(ctx *gin.Context) responder.Responder
 }
 
 func (controller *Controller) updateWorker(ctx *gin.Context) responder.Responder {
-	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeWrite,
-		v1.ServiceAccountRoleWorker); responder != nil {
+	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeWrite); responder != nil {
 		return responder
 	}
 
@@ -84,8 +82,7 @@ func (controller *Controller) updateWorker(ctx *gin.Context) responder.Responder
 }
 
 func (controller *Controller) getWorker(ctx *gin.Context) responder.Responder {
-	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeRead,
-		v1.ServiceAccountRoleWorker); responder != nil {
+	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeRead); responder != nil {
 		return responder
 	}
 
@@ -102,8 +99,7 @@ func (controller *Controller) getWorker(ctx *gin.Context) responder.Responder {
 }
 
 func (controller *Controller) listWorkers(ctx *gin.Context) responder.Responder {
-	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeRead,
-		v1.ServiceAccountRoleWorker); responder != nil {
+	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeRead); responder != nil {
 		return responder
 	}
 
@@ -118,8 +114,7 @@ func (controller *Controller) listWorkers(ctx *gin.Context) responder.Responder 
 }
 
 func (controller *Controller) deleteWorker(ctx *gin.Context) responder.Responder {
-	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeWrite,
-		v1.ServiceAccountRoleWorker); responder != nil {
+	if responder := controller.authorize(ctx, v1.ServiceAccountRoleComputeWrite); responder != nil {
 		return responder
 	}
 

--- a/internal/controller/rpc.go
+++ b/internal/controller/rpc.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (controller *Controller) Watch(_ *emptypb.Empty, stream rpc.Controller_WatchServer) error {
-	if !controller.authorizeGRPC(stream.Context(), v1pkg.ServiceAccountRoleWorker) {
+	if !controller.authorizeGRPC(stream.Context(), v1pkg.ServiceAccountRoleComputeWrite) {
 		return status.Errorf(codes.Unauthenticated, "auth failed")
 	}
 
@@ -40,7 +40,7 @@ func (controller *Controller) Watch(_ *emptypb.Empty, stream rpc.Controller_Watc
 }
 
 func (controller *Controller) PortForward(stream rpc.Controller_PortForwardServer) error {
-	if !controller.authorizeGRPC(stream.Context(), v1pkg.ServiceAccountRoleWorker) {
+	if !controller.authorizeGRPC(stream.Context(), v1pkg.ServiceAccountRoleComputeWrite) {
 		return status.Errorf(codes.Unauthenticated, "auth failed")
 	}
 

--- a/pkg/resource/v1/service_account_role.go
+++ b/pkg/resource/v1/service_account_role.go
@@ -10,7 +10,6 @@ var ErrUnsupportedServiceAccountRole = errors.New("unsupported service account r
 type ServiceAccountRole string
 
 const (
-	ServiceAccountRoleWorker       ServiceAccountRole = "worker"
 	ServiceAccountRoleComputeRead  ServiceAccountRole = "compute:read"
 	ServiceAccountRoleComputeWrite ServiceAccountRole = "compute:write"
 	ServiceAccountRoleAdminRead    ServiceAccountRole = "admin:read"
@@ -19,8 +18,6 @@ const (
 
 func NewServiceAccountRole(name string) (ServiceAccountRole, error) {
 	switch name {
-	case string(ServiceAccountRoleWorker):
-		return ServiceAccountRoleWorker, nil
 	case string(ServiceAccountRoleComputeRead):
 		return ServiceAccountRoleComputeRead, nil
 	case string(ServiceAccountRoleComputeWrite):
@@ -36,7 +33,6 @@ func NewServiceAccountRole(name string) (ServiceAccountRole, error) {
 
 func AllServiceAccountRoles() []ServiceAccountRole {
 	return []ServiceAccountRole{
-		ServiceAccountRoleWorker,
 		ServiceAccountRoleComputeRead,
 		ServiceAccountRoleComputeWrite,
 		ServiceAccountRoleAdminRead,


### PR DESCRIPTION
Let's simplify things for now and only require two roles for worker: `compute:read` and `compute:write`.

A `worker` role might be re-introduced in the future, with a more granular functionality: the holder of that role will be able to create a temporary service account which will be tied to a specific worker. This way we'll be able to do more granular checks since we'll know which working is interacting with the API.

See https://github.com/cirruslabs/orchard/issues/54.