### PR TITLE
Fixed `logs` gluing the lines together.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dupl
     - errcheck
     - exhaustive
@@ -113,6 +112,9 @@ linters:
 
     # Unfortunately too much false-positives, e.g. for a 0700 umask or number 10 when using strconv.FormatInt()
     - gomnd
+
+    # Needs package whitelists
+    - depguard
 
 issues:
   # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.

--- a/internal/command/logs/vm.go
+++ b/internal/command/logs/vm.go
@@ -31,7 +31,7 @@ func runLogsVM(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, line := range lines {
-		fmt.Print(line)
+		fmt.Println(line)
 	}
 
 	return nil


### PR DESCRIPTION
Given:

```
$ orchard create vm v --startup-script 'for i in $(seq 1 10); do echo "$i."; done'
```

Before:
```
$ orchard logs vm v
1.2.3.4.5.6.7.8.9.10.$
```

After:
```
$ orchard-local logs vm v
1.
2.
3.
4.
5.
6.
7.
8.
9.
10.
$ 
```