### PR TITLE
Change event prefix to preserve order under load

### DIFF
--- a/internal/tests/integration_test.go
+++ b/internal/tests/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/exp/slices"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -41,7 +42,7 @@ func TestSingleVM(t *testing.T) {
 		Headless: true,
 		Status:   v1.VMStatusPending,
 		StartupScript: &v1.VMScript{
-			ScriptContent: "echo \"Hello, $FOO!\"",
+			ScriptContent: "echo \"Hello, $FOO!\"\nfor i in $(seq 1 1000); do echo \"$i\"; done",
 			Env:           map[string]string{"FOO": "Bar"},
 		},
 	})
@@ -73,7 +74,11 @@ func TestSingleVM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, []string{"Hello, Bar!"}, logLines)
+	expectedLogs := []string{"Hello, Bar!"}
+	for i := 1; i <= 1000; i++ {
+		expectedLogs = append(expectedLogs, strconv.Itoa(i))
+	}
+	assert.Equal(t, expectedLogs, logLines)
 
 	// Ensure that the VM exists on disk before deleting it
 	require.True(t, hasVMByPredicate(t, func(info tart.VMInfo) bool {


### PR DESCRIPTION
When there are a lot of events streamed from a worker, it's possible to have two batches coming for the same timestamp (which is a timestamp of the event on the worker). This way the existing logic would mess up the order because `index` and the random number doesn't guarantee the order.

To fix this I've changed the format of the prefix for the event to include tro things:

1. Timestamp in nanoseconds of the injection time on the controller so two sequential batches will have guaranteed order unless they are processed within a nanosecond.
2. Made the `index` being fixed length with trailing zeros, so they are properly lexicographically sorted (`000001`, `000002`, ...).

Fixes #88