### PR TITLE
Certificate-less bootstrap tokens

### DIFF
--- a/internal/bootstraptoken/bootstraptoken_test.go
+++ b/internal/bootstraptoken/bootstraptoken_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func TestBootstrapTokenTwoWay(t *testing.T) {
-	serviceAccountName := "admin"
-	serviceAccountToken := uuid.New().String()
-
 	tlsCert, err := controllercmd.GenerateSelfSignedControllerCertificate()
 	require.NoError(t, err)
 
@@ -22,7 +19,19 @@ func TestBootstrapTokenTwoWay(t *testing.T) {
 	}
 	certificatePEM := pem.EncodeToMemory(block)
 
-	bootstrapTokenOld, err := bootstraptoken.New(certificatePEM, serviceAccountName, serviceAccountToken)
+	bootstrapTokenOld, err := bootstraptoken.New(certificatePEM, uuid.NewString(), uuid.NewString())
+	require.NoError(t, err)
+
+	bootstrapTokenNew, err := bootstraptoken.NewFromString(bootstrapTokenOld.String())
+	require.NoError(t, err)
+
+	require.Equal(t, bootstrapTokenOld.ServiceAccountName(), bootstrapTokenNew.ServiceAccountName())
+	require.Equal(t, bootstrapTokenOld.ServiceAccountToken(), bootstrapTokenNew.ServiceAccountToken())
+	require.Equal(t, bootstrapTokenOld.Certificate(), bootstrapTokenNew.Certificate())
+}
+
+func TestBootstrapTokenTwoWayEmptyCertificate(t *testing.T) {
+	bootstrapTokenOld, err := bootstraptoken.New([]byte{}, uuid.NewString(), uuid.NewString())
 	require.NoError(t, err)
 
 	bootstrapTokenNew, err := bootstraptoken.NewFromString(bootstrapTokenOld.String())


### PR DESCRIPTION
In #86, Orchard was starting to create certificate-less contexts for Controllers that are using PKI-compatible certificates.

However, I've overlooked the fact the we also need to add the certificate-less support to the bootstrap tokens.

Resolves https://github.com/cirruslabs/orchard/issues/86.