### PR TITLE
Use os.MkdirAll instead of os.Mkdir to create Orchard's home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Orchard Controller instance is secured by default and all API calls are authenti
 
 In addition to controlling the Orchard via the CLI arguments, there are environment variables that may be beneficial both when automating Orchard and in daily use:
 
-| Variable name                   | Description                                                                        |
-|---------------------------------|------------------------------------------------------------------------------------|
-| `ORCHARD_URL`                   | Override controller URL on per-command basis                                       |
-| `ORCHARD_SERVICE_ACCOUNT_NAME`  | Override service account name (used for controller API auth) on per-command basis  |
-| `ORCHARD_SERVICE_ACCOUNT_TOKEN` | Override service account token (used for controller API auth) on per-command basis |
+| Variable name                   | Description                                                                                                          |
+|---------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `ORCHARD_URL`                   | Override controller URL on per-command basis                                                                         |
+| `ORCHARD_SERVICE_ACCOUNT_NAME`  | Override service account name (used for controller API auth) on per-command basis                                    |
+| `ORCHARD_SERVICE_ACCOUNT_TOKEN` | Override service account token (used for controller API auth) on per-command basis                                   |
+| `ORCHARD_HOME`                  | Override Orchard's home directory. Useful when running multiple Orchard instances on the same host and when testing. |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In addition to controlling the Orchard via the CLI arguments, there are environm
 
 | Variable name                   | Description                                                                                                          |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `ORCHARD_URL`                   | Override controller URL on per-command basis                                                                         |
+| `ORCHARD_HOME`                  | Override Orchard's home directory. Useful when running multiple Orchard instances on the same host and when testing. |
 | `ORCHARD_SERVICE_ACCOUNT_NAME`  | Override service account name (used for controller API auth) on per-command basis                                    |
 | `ORCHARD_SERVICE_ACCOUNT_TOKEN` | Override service account token (used for controller API auth) on per-command basis                                   |
-| `ORCHARD_HOME`                  | Override Orchard's home directory. Useful when running multiple Orchard instances on the same host and when testing. |
+| `ORCHARD_URL`                   | Override controller URL on per-command basis                                                                         |

--- a/internal/orchardhome/orchardhome.go
+++ b/internal/orchardhome/orchardhome.go
@@ -21,7 +21,7 @@ func Path() (string, error) {
 
 	orchardDir := filepath.Join(homeDir, ".orchard")
 
-	if err := os.Mkdir(orchardDir, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(orchardDir, 0700); err != nil && !os.IsExist(err) {
 		return "", fmt.Errorf("%w: cannot create directory %s: %v",
 			ErrFailed, orchardDir, err)
 	}


### PR DESCRIPTION
Otherwise the Docker container fails to start:

```
% docker run -it --rm ghcr.io/cirruslabs/orchard:0.9.0       
2023/06/26 15:18:56 failed to retrieve Orchard's home directory path: cannot create directory /data/.orchard: mkdir /data/.orchard: no such file or directory
```