### PR TITLE
More RPC-related logs

### DIFF
--- a/internal/concurrentmap/concurrentmap.go
+++ b/internal/concurrentmap/concurrentmap.go
@@ -5,17 +5,17 @@ import (
 )
 
 type ConcurrentMap[T any] struct {
-	nonConcurrentMap map[any]T
+	nonConcurrentMap map[string]T
 	mtx              sync.Mutex
 }
 
 func NewConcurrentMap[T any]() *ConcurrentMap[T] {
 	return &ConcurrentMap[T]{
-		nonConcurrentMap: map[any]T{},
+		nonConcurrentMap: map[string]T{},
 	}
 }
 
-func (cmap *ConcurrentMap[T]) Load(key any) (T, bool) {
+func (cmap *ConcurrentMap[T]) Load(key string) (T, bool) {
 	cmap.mtx.Lock()
 	defer cmap.mtx.Unlock()
 
@@ -24,14 +24,14 @@ func (cmap *ConcurrentMap[T]) Load(key any) (T, bool) {
 	return result, ok
 }
 
-func (cmap *ConcurrentMap[T]) Store(id any, value T) {
+func (cmap *ConcurrentMap[T]) Store(id string, value T) {
 	cmap.mtx.Lock()
 	defer cmap.mtx.Unlock()
 
 	cmap.nonConcurrentMap[id] = value
 }
 
-func (cmap *ConcurrentMap[T]) Delete(key any) {
+func (cmap *ConcurrentMap[T]) Delete(key string) {
 	cmap.mtx.Lock()
 	defer cmap.mtx.Unlock()
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -100,6 +100,7 @@ func New(opts ...Option) (*Controller, error) {
 		return nil, err
 	}
 	controller.store = store
+	controller.workerNotifier = notifier.NewNotifier(controller.logger.With("component", "rpc"))
 	controller.scheduler = scheduler.NewScheduler(store, controller.workerNotifier,
 		controller.workerOfflineTimeout, controller.logger)
 
@@ -112,8 +113,6 @@ func New(opts ...Option) (*Controller, error) {
 	} else {
 		controller.listener = listener
 	}
-
-	controller.workerNotifier = notifier.NewNotifier(controller.logger.With("component", "rpc"))
 
 	apiServer := controller.initAPI()
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -58,7 +58,6 @@ type Controller struct {
 
 func New(opts ...Option) (*Controller, error) {
 	controller := &Controller{
-		workerNotifier:       notifier.NewNotifier(),
 		proxy:                proxy.NewProxy(),
 		workerOfflineTimeout: 3 * time.Minute,
 		maxWorkersPerLicense: maxWorkersPerDefaultLicense,
@@ -113,6 +112,8 @@ func New(opts ...Option) (*Controller, error) {
 	} else {
 		controller.listener = listener
 	}
+
+	controller.workerNotifier = notifier.NewNotifier(controller.logger.With("component", "rpc"))
 
 	apiServer := controller.initAPI()
 

--- a/internal/controller/notifier/notifier_test.go
+++ b/internal/controller/notifier/notifier_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cirruslabs/orchard/internal/controller/notifier"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"sync"
 	"testing"
 	"time"
@@ -14,7 +15,7 @@ import (
 func TestNotifier(t *testing.T) {
 	ctx := context.Background()
 
-	notifier := notifier.NewNotifier()
+	notifier := notifier.NewNotifier(zap.NewNop().Sugar())
 
 	var topic = uuid.New().String()
 

--- a/internal/worker/rpc.go
+++ b/internal/worker/rpc.go
@@ -21,6 +21,8 @@ import (
 )
 
 func (worker *Worker) watchRPC(ctx context.Context) error {
+	worker.logger.Infof("connecting to %s over gRPC", worker.client.GRPCTarget())
+
 	conn, err := grpc.Dial(worker.client.GRPCTarget(),
 		grpc.WithTransportCredentials(worker.client.GRPCTransportCredentials()),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
@@ -31,6 +33,8 @@ func (worker *Worker) watchRPC(ctx context.Context) error {
 		return err
 	}
 
+	worker.logger.Infof("gRPC connection established, starting gRPC stream with the controller")
+
 	client := rpc.NewControllerClient(conn)
 
 	ctxWithMetadata := metadata.NewOutgoingContext(ctx, worker.grpcMetadata())
@@ -39,6 +43,8 @@ func (worker *Worker) watchRPC(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	worker.logger.Infof("running gRPC stream with the controller")
 
 	for {
 		watchFromController, err := stream.Recv()


### PR DESCRIPTION
* Controller: `--debug` logs will now show notifier events related to worker addition and removal
* Worker: logs will now show more verbose details w.r.t. gRPC connection progress

Should help with debugging the https://github.com/cirruslabs/orchard/issues/126 and https://github.com/cirruslabs/orchard/issues/118.