### PR TITLE
Worker: better cleanup mechanisms

### DIFF
--- a/internal/command/dev/dev.go
+++ b/internal/command/dev/dev.go
@@ -54,10 +54,10 @@ func runDev(cmd *cobra.Command, args []string) error {
 	devController, devWorker, err := CreateDevControllerAndWorker(devDataDirPath,
 		fmt.Sprintf(":%d", netconstants.DefaultControllerPort), resources,
 		nil, nil)
-
 	if err != nil {
 		return err
 	}
+	defer devWorker.Close()
 
 	errChan := make(chan error, 2)
 

--- a/internal/command/list/vms.go
+++ b/internal/command/list/vms.go
@@ -40,13 +40,13 @@ func runListVMs(cmd *cobra.Command, args []string) error {
 
 	table := uitable.New()
 
-	table.AddRow("Name", "Created", "Image", "Status", "Restart policy")
+	table.AddRow("Name", "Created", "Image", "Status", "Restart policy", "Assigned worker")
 
 	for _, vm := range vms {
 		restartPolicyInfo := fmt.Sprintf("%s (%d restarts)", vm.RestartPolicy, vm.RestartCount)
 		createdAtInfo := humanize.RelTime(vm.CreatedAt, time.Now(), "ago", "in the future")
 
-		table.AddRow(vm.Name, createdAtInfo, vm.Image, vm.Status, restartPolicyInfo)
+		table.AddRow(vm.Name, createdAtInfo, vm.Image, vm.Status, restartPolicyInfo, vm.Worker)
 	}
 
 	fmt.Println(table)

--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -105,6 +105,7 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	defer workerInstance.Close()
 
 	return workerInstance.Run(cmd.Context())
 }

--- a/internal/worker/vmmanager/vm.go
+++ b/internal/worker/vmmanager/vm.go
@@ -190,22 +190,23 @@ func (vm *VM) IP(ctx context.Context) (string, error) {
 	return strings.TrimSpace(stdout), nil
 }
 
-func (vm *VM) Stop() error {
+func (vm *VM) Stop() {
 	if !vm.cloned {
-		return nil
+		return
 	}
 
 	vm.logger.Debugf("stopping VM")
 
-	_, _, _ = tart.Tart(context.Background(), vm.logger, "stop", vm.id())
+	_, _, err := tart.Tart(context.Background(), vm.logger, "stop", vm.id())
+	if err != nil {
+		vm.logger.Warnf("failed to stop VM: %v", err)
+	}
 
 	vm.logger.Debugf("VM stopped")
 
 	vm.cancel()
 
 	vm.wg.Wait()
-
-	return nil
 }
 
 func (vm *VM) Delete() error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -197,7 +197,7 @@ func (worker *Worker) syncVMs(ctx context.Context) error {
 	}
 
 	worker.logger.Infof("syncing %d local VMs against %d remote VMs...",
-		len(remoteVMsIndex), worker.vmm.Len())
+		worker.vmm.Len(), len(remoteVMsIndex))
 
 	// It's important to check the remote VMs against local ones first
 	// to stop the failed VMs before we start the new VMs, otherwise we


### PR DESCRIPTION
Also avoid violating resource constraints by stopping the VM's (1) before we report them as failed and (2) right after receiving the failed status from the Controller.

Resolves #138.