### PR TITLE
Support URLs in hostDir policies

### DIFF
--- a/pkg/resource/v1/host_dir_policy.go
+++ b/pkg/resource/v1/host_dir_policy.go
@@ -14,9 +14,38 @@ type HostDirPolicy struct {
 }
 
 func NewHostDirPolicyFromString(s string) (HostDirPolicy, error) {
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return HostDirPolicy{
+			PathPrefix: strings.TrimSuffix(s, ":ro"),
+			ReadOnly:   strings.HasSuffix(s, ":ro"),
+		}, nil
+	}
+
+	parts := strings.Split(s, ":")
+
+	if len(parts) > 2 {
+		return HostDirPolicy{}, fmt.Errorf("%w: hostDir policy should contain 2 parts at max, found %d",
+			ErrInvalidHostDirPolicy, len(parts))
+	}
+
+	if parts[0] == "" {
+		return HostDirPolicy{}, fmt.Errorf("%w: path prefix cannot be empty", ErrInvalidHostDirPolicy)
+	}
+
+	var readOnly bool
+
+	if len(parts) == 2 {
+		if parts[1] == "ro" {
+			readOnly = true
+		} else {
+			return HostDirPolicy{}, fmt.Errorf("%w: hostDir policy's second part can only be \"ro\", found %q",
+				ErrInvalidHostDirPolicy, parts[1])
+		}
+	}
+
 	return HostDirPolicy{
-		PathPrefix: strings.TrimSuffix(s, ":ro"),
-		ReadOnly:   strings.HasSuffix(s, ":ro"),
+		PathPrefix: parts[0],
+		ReadOnly:   readOnly,
 	}, nil
 }
 

--- a/pkg/resource/v1/host_dir_policy.go
+++ b/pkg/resource/v1/host_dir_policy.go
@@ -14,31 +14,9 @@ type HostDirPolicy struct {
 }
 
 func NewHostDirPolicyFromString(s string) (HostDirPolicy, error) {
-	parts := strings.Split(s, ":")
-
-	if len(parts) > 2 {
-		return HostDirPolicy{}, fmt.Errorf("%w: hostDir policy should contain 2 parts at max, found %d",
-			ErrInvalidHostDirPolicy, len(parts))
-	}
-
-	if parts[0] == "" {
-		return HostDirPolicy{}, fmt.Errorf("%w: path prefix cannot be empty", ErrInvalidHostDirPolicy)
-	}
-
-	var readOnly bool
-
-	if len(parts) == 2 {
-		if parts[1] == "ro" {
-			readOnly = true
-		} else {
-			return HostDirPolicy{}, fmt.Errorf("%w: hostDir policy's second part can only be \"ro\", found %q",
-				ErrInvalidHostDirPolicy, parts[1])
-		}
-	}
-
 	return HostDirPolicy{
-		PathPrefix: parts[0],
-		ReadOnly:   readOnly,
+		PathPrefix: strings.TrimSuffix(s, ":ro"),
+		ReadOnly:   strings.HasSuffix(s, ":ro"),
 	}, nil
 }
 

--- a/pkg/resource/v1/host_dir_policy_test.go
+++ b/pkg/resource/v1/host_dir_policy_test.go
@@ -61,3 +61,13 @@ func TestHostDirPolicyString(t *testing.T) {
 	policyRo := &v1.HostDirPolicy{PathPrefix: "/Users/ci/src", ReadOnly: true}
 	require.EqualValues(t, "/Users/ci/src:ro", policyRo.String())
 }
+
+func TestHTTPHostDirPolicyString(t *testing.T) {
+	policy, err := v1.NewHostDirPolicyFromString("https://github.com/actions/runner/releases/download")
+	require.NoError(t, err)
+	require.EqualValues(t, v1.HostDirPolicy{
+		PathPrefix: "https://github.com/actions/runner/releases/download",
+		ReadOnly:   false,
+	}, policy)
+	require.True(t, policy.Validate("https://github.com/actions/runner/releases/download/v2.309.0/actions-runner-osx-arm64-2.309.0.tar.gz", false))
+}

--- a/pkg/resource/v1/host_dir_policy_test.go
+++ b/pkg/resource/v1/host_dir_policy_test.go
@@ -69,5 +69,6 @@ func TestHTTPHostDirPolicyString(t *testing.T) {
 		PathPrefix: "https://github.com/actions/runner/releases/download",
 		ReadOnly:   false,
 	}, policy)
+	//nolint: lll
 	require.True(t, policy.Validate("https://github.com/actions/runner/releases/download/v2.309.0/actions-runner-osx-arm64-2.309.0.tar.gz", false))
 }


### PR DESCRIPTION
We can't just blindly allow remote URLs since they might contain symlinks leading to outside the archive. Instead, let's support specifying URLs where the remote archive can come from.

Fixes #145