### PR TITLE
Set HTTP client timeout to 30 seconds

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"nhooyr.io/websocket"
+	"time"
 )
 
 var (
@@ -77,6 +78,7 @@ func New(opts ...Option) (*Client, error) {
 
 	// Instantiate the HTTP client
 	client.httpClient = &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: client.tlsConfig,
 		},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -78,6 +78,10 @@ func New(opts ...Option) (*Client, error) {
 
 	// Instantiate the HTTP client
 	client.httpClient = &http.Client{
+		// The default is zero, which means no timeout, which means that
+		// the requests may hang indefinitely. See [1] for more details.
+		//
+		// [1]: https://github.com/cirruslabs/orchard/issues/152#issuecomment-1927091747
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: client.tlsConfig,


### PR DESCRIPTION
There's no timeout by default, which may result Orchard CLI or Worker hanging waiting for request to complete.

See https://github.com/cirruslabs/orchard/issues/152.