### PR TITLE
API: do not return null when methods returning a list have no items

### DIFF
--- a/internal/controller/store/badger/badger_cluster_settings.go
+++ b/internal/controller/store/badger/badger_cluster_settings.go
@@ -7,7 +7,7 @@ import (
 
 var ClusterSettingsKey = []byte("/cluster-settings")
 
-func (txn *Transaction) GetClusterSettings() (result *v1.ClusterSettings, err error) {
+func (txn *Transaction) GetClusterSettings() (_ *v1.ClusterSettings, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()

--- a/internal/controller/store/badger/badger_events.go
+++ b/internal/controller/store/badger/badger_events.go
@@ -45,10 +45,14 @@ func (txn *Transaction) AppendEvents(events []v1.Event, scope ...string) (err er
 	return nil
 }
 
-func (txn *Transaction) ListEvents(scope ...string) (result []v1.Event, err error) {
+func (txn *Transaction) ListEvents(scope ...string) (_ []v1.Event, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
+
+	// Declare an empty, non-nil slice to
+	// return [] when no events are found
+	result := []v1.Event{}
 
 	it := txn.badgerTxn.NewIterator(badger.IteratorOptions{
 		Prefix: scopePrefix(scope),

--- a/internal/controller/store/badger/badger_service_account.go
+++ b/internal/controller/store/badger/badger_service_account.go
@@ -13,7 +13,7 @@ func ServiceAccountKey(name string) []byte {
 	return []byte(path.Join(SpaceServiceAccounts, name))
 }
 
-func (txn *Transaction) GetServiceAccount(name string) (result *v1.ServiceAccount, err error) {
+func (txn *Transaction) GetServiceAccount(name string) (_ *v1.ServiceAccount, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
@@ -65,10 +65,14 @@ func (txn *Transaction) DeleteServiceAccount(name string) (err error) {
 	return txn.badgerTxn.Delete(key)
 }
 
-func (txn *Transaction) ListServiceAccounts() (result []*v1.ServiceAccount, err error) {
+func (txn *Transaction) ListServiceAccounts() (_ []*v1.ServiceAccount, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
+
+	// Declare an empty, non-nil slice to return
+	// [] when no service accounts are found
+	result := []*v1.ServiceAccount{}
 
 	it := txn.badgerTxn.NewIterator(badger.IteratorOptions{
 		Prefix: []byte(SpaceServiceAccounts),

--- a/internal/controller/store/badger/badger_vm.go
+++ b/internal/controller/store/badger/badger_vm.go
@@ -14,7 +14,7 @@ func VMKey(name string) []byte {
 	return []byte(path.Join(SpaceVMs, name))
 }
 
-func (txn *Transaction) GetVM(name string) (result *v1.VM, err error) {
+func (txn *Transaction) GetVM(name string) (_ *v1.VM, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
@@ -66,10 +66,14 @@ func (txn *Transaction) DeleteVM(name string) (err error) {
 	return txn.badgerTxn.Delete(key)
 }
 
-func (txn *Transaction) ListVMs() (result []v1.VM, err error) {
+func (txn *Transaction) ListVMs() (_ []v1.VM, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
+
+	// Declare an empty, non-nil slice to
+	// return [] when no VMs are found
+	result := []v1.VM{}
 
 	it := txn.badgerTxn.NewIterator(badger.IteratorOptions{
 		Prefix: []byte(SpaceVMs),

--- a/internal/controller/store/badger/badger_worker.go
+++ b/internal/controller/store/badger/badger_worker.go
@@ -14,7 +14,7 @@ func WorkerKey(name string) []byte {
 	return []byte(path.Join(SpaceWorkers, name))
 }
 
-func (txn *Transaction) GetWorker(name string) (result *v1.Worker, err error) {
+func (txn *Transaction) GetWorker(name string) (_ *v1.Worker, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
@@ -66,10 +66,14 @@ func (txn *Transaction) DeleteWorker(name string) (err error) {
 	return txn.badgerTxn.Delete(key)
 }
 
-func (txn *Transaction) ListWorkers() (result []v1.Worker, err error) {
+func (txn *Transaction) ListWorkers() (_ []v1.Worker, err error) {
 	defer func() {
 		err = mapErr(err)
 	}()
+
+	// Declare an empty, non-nil slice to
+	// return [] when no workers are found
+	result := []v1.Worker{}
 
 	it := txn.badgerTxn.NewIterator(badger.IteratorOptions{
 		Prefix: []byte(SpaceWorkers),

--- a/pkg/resource/v1/cluster_settings.go
+++ b/pkg/resource/v1/cluster_settings.go
@@ -1,5 +1,5 @@
 package v1
 
 type ClusterSettings struct {
-	HostDirPolicies []HostDirPolicy `json:"hostDirPolicies"`
+	HostDirPolicies []HostDirPolicy `json:"hostDirPolicies,omitempty"`
 }

--- a/pkg/resource/v1/host_dir.go
+++ b/pkg/resource/v1/host_dir.go
@@ -9,9 +9,9 @@ import (
 var ErrInvalidHostDir = errors.New("invalid hostDir specification")
 
 type HostDir struct {
-	Name     string `json:"name"`
-	Path     string `json:"path"`
-	ReadOnly bool   `json:"ro"`
+	Name     string `json:"name,omitempty"`
+	Path     string `json:"path,omitempty"`
+	ReadOnly bool   `json:"ro,omitempty"`
 }
 
 func NewHostDirFromString(s string) (HostDir, error) {

--- a/pkg/resource/v1/host_dir_policy.go
+++ b/pkg/resource/v1/host_dir_policy.go
@@ -9,8 +9,8 @@ import (
 var ErrInvalidHostDirPolicy = errors.New("invalid hostDir policy")
 
 type HostDirPolicy struct {
-	PathPrefix string `json:"pathPrefix"`
-	ReadOnly   bool   `json:"ro"`
+	PathPrefix string `json:"pathPrefix,omitempty"`
+	ReadOnly   bool   `json:"ro,omitempty"`
 }
 
 func NewHostDirPolicyFromString(s string) (HostDirPolicy, error) {

--- a/pkg/resource/v1/service_account.go
+++ b/pkg/resource/v1/service_account.go
@@ -1,8 +1,8 @@
 package v1
 
 type ServiceAccount struct {
-	Token string
-	Roles []ServiceAccountRole
+	Token string               `json:"token,omitempty"`
+	Roles []ServiceAccountRole `json:"roles,omitempty"`
 
 	Meta
 }

--- a/pkg/resource/v1/v1.go
+++ b/pkg/resource/v1/v1.go
@@ -9,61 +9,61 @@ type Meta struct {
 	// Name is a human-readable resource identifier populated by the Worker or Client.
 	//
 	// There can't be multiple resources with the same Name in the DB at any given time.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// CreatedAt is a useful field for scheduler prioritization.
 	//
 	// It is populated by the Controller with the current time
 	// when receiving a POST request.
-	CreatedAt time.Time `json:"createdAt"`
+	CreatedAt time.Time `json:"createdAt,omitempty"`
 }
 
 type VM struct {
-	Image           string          `json:"image"`
-	ImagePullPolicy ImagePullPolicy `json:"imagePullPolicy"`
-	CPU             uint64          `json:"cpu"`
-	Memory          uint64          `json:"memory"`
-	NetSoftnet      bool            `json:"net-softnet"`
-	NetBridged      string          `json:"net-bridged"`
-	Headless        bool            `json:"headless"`
+	Image           string          `json:"image,omitempty"`
+	ImagePullPolicy ImagePullPolicy `json:"imagePullPolicy,omitempty"`
+	CPU             uint64          `json:"cpu,omitempty"`
+	Memory          uint64          `json:"memory,omitempty"`
+	NetSoftnet      bool            `json:"net-softnet,omitempty"`
+	NetBridged      string          `json:"net-bridged,omitempty"`
+	Headless        bool            `json:"headless,omitempty"`
 
 	// Status field is used to track the lifecycle of the VM associated with this resource.
-	Status        VMStatus `json:"status"`
-	StatusMessage string   `json:"status_message"`
+	Status        VMStatus `json:"status,omitempty"`
+	StatusMessage string   `json:"status_message,omitempty"`
 
 	// Worker field is set by the Controller to assign this VM to a specific Worker.
-	Worker string `json:"worker"`
+	Worker string `json:"worker,omitempty"`
 
-	Username      string    `json:"username"`
-	Password      string    `json:"password"`
-	StartupScript *VMScript `json:"startup_script"`
+	Username      string    `json:"username,omitempty"`
+	Password      string    `json:"password,omitempty"`
+	StartupScript *VMScript `json:"startup_script,omitempty"`
 
-	RestartPolicy RestartPolicy `json:"restart_policy"`
-	RestartedAt   time.Time     `json:"restarted_at"`
-	RestartCount  uint64        `json:"restart_count"`
+	RestartPolicy RestartPolicy `json:"restart_policy,omitempty"`
+	RestartedAt   time.Time     `json:"restarted_at,omitempty"`
+	RestartCount  uint64        `json:"restart_count,omitempty"`
 
 	// UID is a useful field for avoiding data races within a single Name.
 	//
 	// It is populated by the Controller when receiving a POST request.
-	UID string `json:"uid"`
+	UID string `json:"uid,omitempty"`
 
 	// Resources required by this VM.
-	Resources Resources `json:"resources"`
+	Resources Resources `json:"resources,omitempty"`
 
 	// HostDir is a list of host directories to be mounted to the VM.
-	HostDirs []HostDir `json:"hostDirs"`
+	HostDirs []HostDir `json:"hostDirs,omitempty"`
 
 	// ImageFQN is a fully qualified name of the Image that it is populated
 	// by the worker using "tart fqn" command after it had pulled the image.
-	ImageFQN string `json:"image_fqn"`
+	ImageFQN string `json:"image_fqn,omitempty"`
 
 	Meta
 }
 
 type Event struct {
-	Kind      EventKind `json:"kind"`
-	Timestamp int64     `json:"timestamp"`
-	Payload   string    `json:"payload"`
+	Kind      EventKind `json:"kind,omitempty"`
+	Timestamp int64     `json:"timestamp,omitempty"`
+	Payload   string    `json:"payload,omitempty"`
 }
 
 type EventKind string
@@ -73,8 +73,8 @@ const (
 )
 
 type VMScript struct {
-	ScriptContent string            `json:"script_content"`
-	Env           map[string]string `json:"env"`
+	ScriptContent string            `json:"script_content,omitempty"`
+	Env           map[string]string `json:"env,omitempty"`
 }
 
 func (vm VM) TerminalState() bool {
@@ -101,6 +101,6 @@ const (
 )
 
 type ControllerInfo struct {
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
+	Version string `json:"version,omitempty"`
+	Commit  string `json:"commit,omitempty"`
 }

--- a/pkg/resource/v1/worker.go
+++ b/pkg/resource/v1/worker.go
@@ -5,14 +5,14 @@ import "time"
 type Worker struct {
 	// LastSeen is set by the Worker and is used by the Controller
 	// to track unhealthy Workers.
-	LastSeen time.Time
+	LastSeen time.Time `json:"last_seen,omitempty"`
 
-	MachineID string
+	MachineID string `json:"machine_id,omitempty"`
 
-	SchedulingPaused bool
+	SchedulingPaused bool `json:"scheduling_paused,omitempty"`
 
 	// Resources available on this Worker.
-	Resources Resources `json:"resources"`
+	Resources Resources `json:"resources,omitempty"`
 
 	Meta
 }


### PR DESCRIPTION
Also use `omitempty` in all API structs to avoid the same issue, but on a nested levels.

Resolves https://github.com/cirruslabs/orchard/issues/169.