### PR TITLE
Randomize the VM's MAC-address when using bridged networking

### DIFF
--- a/internal/worker/vmmanager/vm.go
+++ b/internal/worker/vmmanager/vm.go
@@ -200,6 +200,18 @@ func (vm *VM) cloneAndConfigure(ctx context.Context) error {
 			return err
 		}
 	}
+
+	// Randomize the VM's MAC-address when using bridged networking
+	// to avoid collisions when cloning from an OCI image on multiple hosts
+	//
+	// See https://github.com/cirruslabs/orchard/issues/181 for more details.
+	if vm.Resource.NetBridged != "" {
+		_, _, err = tart.Tart(ctx, vm.logger, "set", "--random-mac")
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Since DHCP shortage is not an issue when using `--net-bridged`, we can safely do that, while resolving https://github.com/cirruslabs/orchard/issues/181.