### PR TITLE
.cirrus.yml: specify resources required on the "dev-mini"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,8 @@ task:
   persistent_worker:
     labels:
       name: dev-mini
+    resources:
+      tart-vms: 1
   pull_script:
     - tart pull ghcr.io/cirruslabs/macos-sonoma-base:latest
   test_script:


### PR DESCRIPTION
Otherwise it's possible to get the "2 VMs max." error from the Virtualization.Framework.