### PR TITLE
Expose 2 new metrics about worker health

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -99,9 +99,11 @@ func (scheduler *Scheduler) reportStats(workers []v1.Worker, vms []v1.VM) {
 		workersLastSeen.With(map[string]string{"worker_name": worker.Name}).Set(float64(worker.LastSeen.Unix()))
 		if worker.Offline(scheduler.workerOfflineTimeout) {
 			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(0)
+			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "offline"}).Set(1)
 			workersStat.With(map[string]string{"status": "offline"}).Inc()
 		} else {
 			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(1)
+			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "offline"}).Set(0)
 			workersStat.With(map[string]string{"status": "online"}).Inc()
 		}
 	}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -28,6 +28,12 @@ var (
 	workersStat = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "orchard_workers",
 	}, []string{"status"})
+	workersStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "orchard_worker_status",
+	}, []string{"worker_name", "status"})
+	workersLastSeen = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "orchard_worker_last_seen",
+	}, []string{"worker_name"})
 	vmsStat = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "orchard_vms",
 	}, []string{"status"})
@@ -90,9 +96,12 @@ func (scheduler *Scheduler) Run() {
 
 func (scheduler *Scheduler) reportStats(workers []v1.Worker, vms []v1.VM) {
 	for _, worker := range workers {
+		workersLastSeen.With(map[string]string{"worker_name": worker.Name}).Set(float64(worker.LastSeen.Unix()))
 		if worker.Offline(scheduler.workerOfflineTimeout) {
+			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(0)
 			workersStat.With(map[string]string{"status": "offline"}).Inc()
 		} else {
+			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(1)
 			workersStat.With(map[string]string{"status": "online"}).Inc()
 		}
 	}

--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -27,13 +27,7 @@ var (
 	})
 	workersStat = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "orchard_workers",
-	}, []string{"status"})
-	workersStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "orchard_worker_status",
 	}, []string{"worker_name", "status"})
-	workersLastSeen = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "orchard_worker_last_seen",
-	}, []string{"worker_name"})
 	vmsStat = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "orchard_vms",
 	}, []string{"status"})
@@ -96,15 +90,12 @@ func (scheduler *Scheduler) Run() {
 
 func (scheduler *Scheduler) reportStats(workers []v1.Worker, vms []v1.VM) {
 	for _, worker := range workers {
-		workersLastSeen.With(map[string]string{"worker_name": worker.Name}).Set(float64(worker.LastSeen.Unix()))
 		if worker.Offline(scheduler.workerOfflineTimeout) {
-			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(0)
-			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "offline"}).Set(1)
-			workersStat.With(map[string]string{"status": "offline"}).Inc()
+			workersStat.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(0)
+			workersStat.With(map[string]string{"worker_name": worker.Name, "status": "offline"}).Set(1)
 		} else {
-			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(1)
-			workersStatus.With(map[string]string{"worker_name": worker.Name, "status": "offline"}).Set(0)
-			workersStat.With(map[string]string{"status": "online"}).Inc()
+			workersStat.With(map[string]string{"worker_name": worker.Name, "status": "online"}).Set(1)
+			workersStat.With(map[string]string{"worker_name": worker.Name, "status": "offline"}).Set(0)
 		}
 	}
 	for _, vm := range vms {


### PR DESCRIPTION
This exposes 2 new metrics around worker health:

```
# HELP orchard_worker_last_seen
# TYPE orchard_worker_last_seen gauge
orchard_worker_last_seen{worker_name="Marks-Worker"} 1.725530969e+09
```

and
```
# HELP orchard_worker_status
# TYPE orchard_worker_status gauge
orchard_worker_status{status="online",worker_name="Marks-Worker"} 1
```

That way we can explicitly alert if a node goes offline. 

