### PR TITLE
orchard-controller .deb/.rpm package: install systemd service

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ release:
   prerelease: auto
 
 nfpms:
-  - package_name: orchard
+  - package_name: orchard-controller
     vendor: Cirrus Labs, Inc.
     homepage: https://github.com/cirruslabs/orchard
     maintainer: support@cirruslabs.org
@@ -39,6 +39,14 @@ nfpms:
     formats:
       - deb
       - rpm
+    contents:
+      - src: packaging/orchard-controller.service
+        dst: /lib/systemd/system/orchard-controller.service
+        type: config
+    scripts:
+      postinstall: packaging/postinstall.sh
+      preremove: packaging/preremove.sh
+      postremove: packaging/postremove.sh
 
 furies:
   - account: cirruslabs

--- a/packaging/orchard-controller.service
+++ b/packaging/orchard-controller.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Orchard Controller
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=orchard-controller
+ExecStart=/usr/bin/orchard controller run
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set shell options to enable fail-fast behavior
+#
+# * -e: fail the script when an error occurs or command fails
+# * -u: fail the script when attempting to reference unset parameters
+# * -o pipefail: by default an exit status of a pipeline is that of its
+#                last command, this fails the pipe early if an error in
+#                any of its commands occurs
+#
+set -euo pipefail
+
+# Create "orchard-controller" user and group
+useradd --system --create-home --home-dir /var/lib/orchard-controller --user-group orchard-controller
+
+# Now that the orchard-controller.service file is installed, reflect the changes in systemd
+systemctl daemon-reload

--- a/packaging/postremove.sh
+++ b/packaging/postremove.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Set shell options to enable fail-fast behavior
+#
+# * -e: fail the script when an error occurs or command fails
+# * -u: fail the script when attempting to reference unset parameters
+# * -o pipefail: by default an exit status of a pipeline is that of its
+#                last command, this fails the pipe early if an error in
+#                any of its commands occurs
+#
+set -euo pipefail
+
+# Delete "orchard-controller" user and group
+if id "orchard-controller" &>/dev/null
+then
+  userdel orchard-controller
+fi
+
+# Now that the orchard-controller.service file is removed, reflect the changes in systemd
+systemctl daemon-reload

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Set shell options to enable fail-fast behavior
+#
+# * -e: fail the script when an error occurs or command fails
+# * -u: fail the script when attempting to reference unset parameters
+# * -o pipefail: by default an exit status of a pipeline is that of its
+#                last command, this fails the pipe early if an error in
+#                any of its commands occurs
+#
+set -euo pipefail
+
+# Stop the service, otherwise we won't be able to remove the "orchard-controller" user
+systemctl stop orchard-controller.service


### PR DESCRIPTION
And create/delete the `orchard-controller` system user for running the Orchard Controller.

Manually tested package installation and removal on `ghcr.io/cirruslabs/ubuntu:latest` and `ghcr.io/cirruslabs/fedora:latest`.