### PR TITLE
Rendezvous: use a buffered channel of size 1

### DIFF
--- a/internal/controller/rendezvous/rendezvous_test.go
+++ b/internal/controller/rendezvous/rendezvous_test.go
@@ -37,3 +37,47 @@ func TestProxy(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestProxyNonBlockingRespond ensures that the Respond() won't block
+// the caller in the absense of the receiving party.
+func TestProxyNonBlockingRespond(t *testing.T) {
+	ctx := context.Background()
+
+	expectedConn, _ := net.Pipe()
+
+	proxy := rendezvous.New[net.Conn]()
+
+	token := uuid.New().String()
+
+	connCh, cancel := proxy.Request(ctx, token)
+	defer cancel()
+
+	// Call Respond() in the same goroutine as Request()
+	_, err := proxy.Respond(token, expectedConn)
+	require.NoError(t, err)
+
+	actualConn := <-connCh
+	require.Equal(t, expectedConn, actualConn)
+}
+
+// TestProxyDoubleRespond ensures that the Respond() can be
+// safely called multiple times.
+func TestProxyDoubleRespond(t *testing.T) {
+	ctx := context.Background()
+
+	expectedConn, _ := net.Pipe()
+
+	proxy := rendezvous.New[net.Conn]()
+
+	token := uuid.New().String()
+
+	_, cancel := proxy.Request(ctx, token)
+	defer cancel()
+
+	// Call Respond() twice
+	_, err := proxy.Respond(token, expectedConn)
+	require.NoError(t, err)
+
+	_, err = proxy.Respond(token, expectedConn)
+	require.NoError(t, err)
+}

--- a/internal/controller/rendezvous/rendezvous_test.go
+++ b/internal/controller/rendezvous/rendezvous_test.go
@@ -39,7 +39,7 @@ func TestProxy(t *testing.T) {
 }
 
 // TestProxyNonBlockingRespond ensures that the Respond() won't block
-// the caller in the absense of the receiving party.
+// the caller in the absence of the receiving party.
 func TestProxyNonBlockingRespond(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
And drop extraneous responses to never block the callers of `Respond()`.