### PR TITLE
Scheduler: stop iterating over workers when candidate worker is found

### DIFF
--- a/internal/controller/scheduler/scheduler.go
+++ b/internal/controller/scheduler/scheduler.go
@@ -150,6 +150,8 @@ func (scheduler *Scheduler) schedulingLoopIteration() error {
 					affectedWorkers[worker.Name] = true
 
 					workerToResources.Add(worker.Name, unscheduledVM.Resources)
+
+					break
 				}
 			}
 		}


### PR DESCRIPTION
Thanks to @hblockx for spotting this in https://github.com/cirruslabs/orchard/issues/212#issuecomment-2470404024.

Related to https://github.com/cirruslabs/orchard/issues/212.