### PR TITLE
Never list workers in Update()/storeUpdate() transactions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,8 +19,6 @@ linters:
     - dupl
     - errcheck
     - exhaustive
-    - exportloopref
-    - exportloopref
     - gochecknoinits
     - gocognit
     - goconst
@@ -96,9 +94,6 @@ linters:
     # No way to disable the "exported" check for the whole project[1]
     # [1]: https://github.com/mgechev/revive/issues/244#issuecomment-560512162
     - revive
-
-    # Unfortunately too much false-positives, e.g. for a 0700 umask or number 10 when using strconv.FormatInt()
-    - gomnd
 
     # Needs package whitelists
     - depguard


### PR DESCRIPTION
With the high enough number of workers, the probability of conflict of a transaction that lists all workers in the system rises as each worker is concurrently poking the API and updating its [`LastSeen`](https://github.com/cirruslabs/orchard/blob/d94690176e328ac27dd0ce9d9a4ce49a12de4f2e/pkg/resource/v1/worker.go#L6-L8) field.

We've fixed that for the scheduler in https://github.com/cirruslabs/orchard/pull/225, but there's two more places remaining in the codebase:

* `POST /v1/workers` — improved in 6c9b4168834ec9df9573f24a90532a5714bad4c4
* `healthCheckingLoopIteration()` — improved in 08cf6687e70d9aa6eb8efec6330567f3328b1b9a