### PR TITLE
Worker: do not consider on-disk VMs syncing error as fatal

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -132,7 +132,9 @@ func (worker *Worker) runNewSession(ctx context.Context) error {
 
 	// Sync on-disk VMs
 	if err := worker.syncOnDiskVMs(ctx); err != nil {
-		return err
+		worker.logger.Errorf("failed to sync on-disk VMs: %v", err)
+
+		return nil
 	}
 
 	for {


### PR DESCRIPTION
The rest of the function calls in [`runNewSession()`](https://github.com/cirruslabs/orchard/blob/d7b6f477e10752eb96137bd0ace1d3ae6aeba431/internal/worker/worker.go#L115-L159) are already handling this properly, yet [`syncOnDiskVMs()`](https://github.com/cirruslabs/orchard/blob/d7b6f477e10752eb96137bd0ace1d3ae6aeba431/internal/worker/worker.go#L133-L136) for some reason was left behind.

This makes the Orchard Worker more robust in the presence of Orchard Controller/network/etc. errors.