### PR TITLE
API: only overwrite specific worker fields when worker already exists

### DIFF
--- a/internal/controller/api_workers.go
+++ b/internal/controller/api_workers.go
@@ -103,7 +103,7 @@ func (controller *Controller) createWorker(ctx *gin.Context) responder.Responder
 			return responder.Error(err)
 		}
 
-		return responder.JSON(200, worker)
+		return responder.JSON(200, dbWorker)
 	})
 }
 

--- a/internal/controller/api_workers.go
+++ b/internal/controller/api_workers.go
@@ -80,6 +80,8 @@ func (controller *Controller) createWorker(ctx *gin.Context) responder.Responder
 				if err := txn.SetWorker(worker); err != nil {
 					return responder.Error(err)
 				}
+
+				return responder.JSON(200, worker)
 			}
 
 			controller.logger.Errorf("failed to check if the worker "+


### PR DESCRIPTION
To avoid accidentally unpausing the worker after it re-registers itself.

Resolves https://github.com/cirruslabs/orchard/issues/231.