### PR TITLE
Prevent goroutine leak when Close()'ing *grpc_net_conn.Conn

### DIFF
--- a/internal/netconncancel/netconncancel.go
+++ b/internal/netconncancel/netconncancel.go
@@ -1,0 +1,24 @@
+package netconncancel
+
+import (
+	"context"
+	"net"
+)
+
+type NetConnCancel struct {
+	Cancel context.CancelFunc
+	net.Conn
+}
+
+func New(netConn net.Conn, cancel context.CancelFunc) *NetConnCancel {
+	return &NetConnCancel{
+		Cancel: cancel,
+		Conn:   netConn,
+	}
+}
+
+func (ncc *NetConnCancel) Close() error {
+	ncc.Cancel()
+
+	return ncc.Conn.Close()
+}


### PR DESCRIPTION
From [`(*grpc_net_conn.Conn).Close()` documentation](https://pkg.go.dev/github.com/mitchellh/go-grpc-net-conn?#Conn.Close):

>Close will close the client if this is a client. If this is a server stream this does nothing since gRPC expects you to close the stream by returning from the RPC call.

So, because it does nothing, we never proceed here (`right` is `*grpc_net_conn.Conn` when called from [`api_vms_portforward.go:110`](https://github.com/cirruslabs/orchard/blob/ac9e936f337a2322dc8027ad2fdd4e6fd74413fb/internal/controller/api_vms_portforward.go#L110)): https://github.com/cirruslabs/orchard/blob/d59bc7f8a7666f1b84778a4709abe29476d96b19/internal/proxy/proxy.go#L37-L38

...which causes a goroutine leak and potentially high memory consumption.