### PR TITLE
Avoid including " and $ characters in bootstrap admin's token

### DIFF
--- a/internal/command/controller/bootstrap.go
+++ b/internal/command/controller/bootstrap.go
@@ -40,9 +40,7 @@ func Bootstrap(controllerInstance *controller.Controller, controllerCert tls.Cer
 				// Avoid generating $ and " symbols
 				// as they cause issues in shell
 				switch r {
-				case '$':
-					fallthrough
-				case '"':
+				case '$', '"':
 					return -1
 				default:
 					return r

--- a/internal/command/controller/bootstrap.go
+++ b/internal/command/controller/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/sethvargo/go-password/password"
 	"os"
+	"strings"
 )
 
 const BootstrapAdminName = "bootstrap-admin"
@@ -31,7 +32,29 @@ func Bootstrap(controllerInstance *controller.Controller, controllerCert tls.Cer
 
 	// Generate a bootstrap admin token if not present in the environment variable
 	if !orchardBootstrapAdminTokenPresent {
-		orchardBootstrapAdminToken, err = password.Generate(32, 10, 10,
+		passwordGenerator, err := password.NewGenerator(&password.GeneratorInput{
+			LowerLetters: password.LowerLetters,
+			UpperLetters: password.UpperLetters,
+			Digits:       password.Digits,
+			Symbols: strings.Map(func(r rune) rune {
+				// Avoid generating $ and " symbols
+				// as they cause issues in shell
+				switch r {
+				case '$':
+					fallthrough
+				case '"':
+					return -1
+				default:
+					return r
+				}
+			}, password.Symbols),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to generate bootstrap admin token: "+
+				"failed to initialize password generator: %w", err)
+		}
+
+		orchardBootstrapAdminToken, err = passwordGenerator.Generate(32, 10, 10,
 			false, false)
 		if err != nil {
 			return fmt.Errorf("failed to generate bootstrap admin token: %w", err)


### PR DESCRIPTION
They cause issues in shell when copy-paste'ing them.