### PR TITLE
Worker: prefer assigned CPU/memory to CPU/memory

### DIFF
--- a/internal/command/get/worker.go
+++ b/internal/command/get/worker.go
@@ -69,15 +69,18 @@ func runGetWorker(cmd *cobra.Command, args []string) error {
 
 	table.AddRow("Machine ID", worker.MachineID)
 	table.AddRow("Scheduling paused", worker.SchedulingPaused)
+	table.AddRow("Default CPU", worker.DefaultCPU)
+	table.AddRow("Default memory", worker.DefaultCPU)
 
-	var resourcesInfo string
-	if len(worker.Resources) != 0 {
-		resourceDescriptions := lo.MapToSlice(worker.Resources, func(key string, value uint64) string {
-			return fmt.Sprintf("%s: %d", key, value)
-		})
-		resourcesInfo = strings.Join(resourceDescriptions, "\n")
-	}
+	resourcesInfo := strings.Join(lo.MapToSlice(worker.Resources, func(key string, value uint64) string {
+		return fmt.Sprintf("%s: %d", key, value)
+	}), "\n")
 	table.AddRow("Resources", nonEmptyOrNone(resourcesInfo))
+
+	labelsInfo := strings.Join(lo.MapToSlice(worker.Labels, func(key string, value string) string {
+		return fmt.Sprintf("%s: %s", key, value)
+	}), "\n")
+	table.AddRow("Labels", nonEmptyOrNone(labelsInfo))
 
 	fmt.Println(table)
 

--- a/internal/worker/vmmanager/vm.go
+++ b/internal/worker/vmmanager/vm.go
@@ -195,17 +195,31 @@ func (vm *VM) cloneAndConfigure(ctx context.Context) error {
 		vm.imageFQN.Store(&fqn)
 	}
 
-	if vm.Resource.Memory != 0 {
+	// Set memory
+	memory := vm.Resource.AssignedMemory
+
+	if memory == 0 {
+		memory = vm.Resource.Memory
+	}
+
+	if memory != 0 {
 		_, _, err = tart.Tart(ctx, vm.logger, "set", "--memory",
-			strconv.FormatUint(vm.Resource.Memory, 10), vm.id())
+			strconv.FormatUint(memory, 10), vm.id())
 		if err != nil {
 			return err
 		}
 	}
 
-	if vm.Resource.CPU != 0 {
+	// Set CPU
+	cpu := vm.Resource.AssignedCPU
+
+	if cpu == 0 {
+		cpu = vm.Resource.CPU
+	}
+
+	if cpu != 0 {
 		_, _, err = tart.Tart(ctx, vm.logger, "set", "--cpu",
-			strconv.FormatUint(vm.Resource.CPU, 10), vm.id())
+			strconv.FormatUint(cpu, 10), vm.id())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Otherwise https://github.com/cirruslabs/orchard/pull/243 would not work.

Also show default CPU, default memory and labels in `orchard get worker`.