### PR TITLE
Controller: advertise ALPN

### DIFF
--- a/internal/command/controller/run.go
+++ b/internal/command/controller/run.go
@@ -103,6 +103,10 @@ func runController(cmd *cobra.Command, args []string) (err error) {
 			Certificates: []tls.Certificate{
 				controllerCert,
 			},
+			// Since gRPC clients started enforcing ALPN at some point, we need to advertise it
+			//
+			// See https://github.com/grpc/grpc-go/issues/7922 for more details.
+			NextProtos: []string{"http/1.1", "h2"},
 		}),
 	}
 


### PR DESCRIPTION
Otherwise we get the following error on the controller:

```
{"level":"warn","ts":1742308335.536402,"caller":"worker/worker.go:158","msg":"failed to watch RPC v1: rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property. If you upgraded from a grpc-go version earlier than 1.67, your TLS connections may have stopped working due to ALPN enforcement. For more details, see: https://github.com/grpc/grpc-go/issues/434\""}
```