### PR TITLE
add enable tls flag

### DIFF
--- a/internal/command/controller/bootstrap.go
+++ b/internal/command/controller/bootstrap.go
@@ -89,9 +89,14 @@ func Bootstrap(controllerInstance *controller.Controller, controllerCert tls.Cer
 		pterm.Sprintln(),
 		pterm.Sprintf("Service account name: %s\n", pterm.Bold.Sprint(BootstrapAdminName)),
 		pterm.Sprintf("Service account token: %s\n", pterm.Bold.Sprint(serviceAccountTokenToDisplay)),
-		pterm.Sprintf("Certificate SHA-256 fingerprint: %s.\n",
-			pterm.Bold.Sprint(certificatefingerprint.CertificateFingerprint(controllerCert.Certificate[0]))),
 	)
+
+	if enableTLS {
+		pterm.Info.Print(
+			pterm.Sprintf("Certificate SHA-256 fingerprint: %s.\n",
+				pterm.Bold.Sprint(certificatefingerprint.CertificateFingerprint(controllerCert.Certificate[0]))),
+		)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Change Summary

Added configuration parameter to control TLS initialization, as TLS termination is centrally handled by the Ingress controller in Kubernetes or other LB service. This eliminates the need for individual services to provide HTTPS endpoints.
