### PR TITLE
Dependabot: group all updates to avoid multiple PRs noise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @edigaryev @fkorotkov

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
Also add `CODEOWNERS`.