### PR TITLE
orchard ssh vm: prevent busy loop in remote terminal resize goroutine

### DIFF
--- a/internal/command/ssh/vm.go
+++ b/internal/command/ssh/vm.go
@@ -132,6 +132,13 @@ func runSSHVM(cmd *cobra.Command, args []string) error {
 	// Periodically adjust remote terminal size
 	go func() {
 		for {
+			select {
+			case <-time.After(time.Second * time.Duration(wait)):
+				// Proceed with adjusting the remote terminal size
+			case <-cmd.Context().Done():
+				return
+			}
+
 			newWidth, newHeight, err := term.GetSize(stdoutFD)
 			if err != nil {
 				return
@@ -147,8 +154,6 @@ func runSSHVM(cmd *cobra.Command, args []string) error {
 
 			height = newHeight
 			width = newWidth
-
-			time.Sleep(time.Second)
 		}
 	}()
 


### PR DESCRIPTION
Props to @nhutchinson-te for finding this 👍 

Resolves https://github.com/cirruslabs/orchard/issues/296.