### PR TITLE
Use VM status message to reflect pulling, cloning, configuring, etc.

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -279,6 +279,12 @@ func (worker *Worker) syncVMs(ctx context.Context) error {
 				if _, err := worker.client.VMs().Update(ctx, remoteVM); err != nil {
 					return err
 				}
+			} else if vm.Status() != remoteVM.StatusMessage {
+				// Report the new VM status message
+				remoteVM.StatusMessage = vm.Status()
+				if _, err := worker.client.VMs().Update(ctx, remoteVM); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This way the user will better understand what's going on behind the `pending` status:

<img width="580" alt="Screenshot 2025-04-03 at 15 08 59" src="https://github.com/user-attachments/assets/f0bde3a1-8d2d-4293-90b9-c0120664c785" />