### PR TITLE
Orchard Worker: don't forget to use localnetworkhelper in RPC and RPCv2

### DIFF
--- a/internal/tests/integration_test.go
+++ b/internal/tests/integration_test.go
@@ -61,7 +61,6 @@ func TestSingleVM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Empty(t, runningVM.StatusMessage)
 	assert.Equal(t, v1.VMStatusRunning, runningVM.Status)
 	assert.True(t, wait.Wait(2*time.Minute, func() bool {
 		logLines, err := devClient.VMs().Logs(context.Background(), "test-vm")
@@ -162,7 +161,6 @@ func TestPortForwarding(t *testing.T) {
 	vm, err := devClient.VMs().Get(ctx, "test-vm")
 	require.NoError(t, err)
 	require.Equal(t, v1.VMStatusRunning, vm.Status)
-	require.Empty(t, vm.StatusMessage)
 
 	t.Logf("Waiting for the VM to start, current status: %s", vm.Status)
 
@@ -407,7 +405,6 @@ func TestHostDirs(t *testing.T) {
 		return vm.Status == v1.VMStatusRunning || vm.Status == v1.VMStatusFailed
 	}), "failed to start a VM")
 
-	require.Empty(t, vm.StatusMessage)
 	require.Equal(t, v1.VMStatusRunning, vm.Status)
 
 	var logLines []string

--- a/internal/worker/rpc.go
+++ b/internal/worker/rpc.go
@@ -109,7 +109,17 @@ func (worker *Worker) handlePortForward(
 	}
 
 	// Connect to the VM's port
-	vmConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", host, portForwardAction.Port))
+	var vmConn net.Conn
+
+	if worker.localNetworkHelper != nil {
+		vmConn, err = worker.localNetworkHelper.PrivilegedDialContext(ctx, "tcp",
+			fmt.Sprintf("%s:%d", host, portForwardAction.Port))
+	} else {
+		dialer := net.Dialer{}
+
+		vmConn, err = dialer.DialContext(ctx, "tcp",
+			fmt.Sprintf("%s:%d", host, portForwardAction.Port))
+	}
 	if err != nil {
 		worker.logger.Warnf("port forwarding failed: failed to connect to the VM: %v", err)
 

--- a/internal/worker/rpcv2.go
+++ b/internal/worker/rpcv2.go
@@ -89,7 +89,18 @@ func (worker *Worker) handlePortForwardV2Inner(
 	}
 
 	// Connect to the VM's port
-	vmConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", host, portForward.Port))
+
+	var vmConn net.Conn
+
+	if worker.localNetworkHelper != nil {
+		vmConn, err = worker.localNetworkHelper.PrivilegedDialContext(ctx, "tcp",
+			fmt.Sprintf("%s:%d", host, portForward.Port))
+	} else {
+		dialer := net.Dialer{}
+
+		vmConn, err = dialer.DialContext(ctx, "tcp",
+			fmt.Sprintf("%s:%d", host, portForward.Port))
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to the VM: %v", err)
 	}


### PR DESCRIPTION
Missing piece of https://github.com/cirruslabs/orchard/pull/302.