### PR TITLE
Worker: fix "failed to retrieve Orchard's home directory path"

### DIFF
--- a/internal/command/controller/controller.go
+++ b/internal/command/controller/controller.go
@@ -1,10 +1,7 @@
 package controller
 
 import (
-	"github.com/cirruslabs/orchard/internal/orchardhome"
 	"github.com/spf13/cobra"
-	"log"
-	"path/filepath"
 )
 
 var dataDirPath string
@@ -17,13 +14,8 @@ func NewCommand() *cobra.Command {
 
 	command.AddCommand(newRunCommand())
 
-	orchardHome, err := orchardhome.Path()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	command.PersistentFlags().StringVar(&dataDirPath, "data-dir", filepath.Join(orchardHome, "controller"),
-		"path to the data controller's directory")
+	command.PersistentFlags().StringVar(&dataDirPath, "data-dir", "",
+		"path to the data controller's directory (defaults to $HOME/.orchard/controller)")
 
 	return command
 }

--- a/internal/command/controller/run.go
+++ b/internal/command/controller/run.go
@@ -8,10 +8,12 @@ import (
 	configpkg "github.com/cirruslabs/orchard/internal/config"
 	"github.com/cirruslabs/orchard/internal/controller"
 	"github.com/cirruslabs/orchard/internal/netconstants"
+	"github.com/cirruslabs/orchard/internal/orchardhome"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"os"
+	"path/filepath"
 	"strconv"
 )
 
@@ -93,6 +95,15 @@ func runController(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Instantiate a data directory and ensure it's initialized
+	if dataDirPath == "" {
+		orchardHome, err := orchardhome.Path()
+		if err != nil {
+			return err
+		}
+
+		dataDirPath = filepath.Join(orchardHome, "controller")
+	}
+
 	dataDir, err := controller.NewDataDir(dataDirPath)
 	if err != nil {
 		return err

--- a/internal/command/worker/worker.go
+++ b/internal/command/worker/worker.go
@@ -3,13 +3,8 @@
 package worker
 
 import (
-	"github.com/cirruslabs/orchard/internal/orchardhome"
 	"github.com/spf13/cobra"
-	"log"
-	"path/filepath"
 )
-
-var dataDirPath string
 
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -18,14 +13,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	command.AddCommand(newRunCommand())
-
-	orchardHome, err := orchardhome.Path()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	command.PersistentFlags().StringVar(&dataDirPath, "data-dir", filepath.Join(orchardHome, "worker"),
-		"path to the worker's data directory")
 
 	return command
 }


### PR DESCRIPTION
When running through launchd and no `HOME` is set.

`orchard worker run` doesn't need `orchardhome.Path()` at all, so it was removed.

And also delay the `orchardhome.Path()` call in `orchard controller` command, otherwise it gets called before the worker drops privileges and sets a proper `HOME`.

Resolves https://github.com/cirruslabs/orchard/issues/308.