### PR TITLE
Controller: periodically send PINGs on all WebSocket connections

### DIFF
--- a/internal/controller/api_rpc_portforward.go
+++ b/internal/controller/api_rpc_portforward.go
@@ -1,12 +1,14 @@
 package controller
 
 import (
+	"context"
 	"github.com/cirruslabs/orchard/internal/controller/rendezvous"
 	"github.com/cirruslabs/orchard/internal/responder"
 	v1 "github.com/cirruslabs/orchard/pkg/resource/v1"
 	"github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 	"net"
+	"time"
 )
 
 func (controller *Controller) rpcPortForward(ctx *gin.Context) responder.Responder {
@@ -36,13 +38,24 @@ func (controller *Controller) rpcPortForward(ctx *gin.Context) responder.Respond
 			"failure to respond with the established WebSocket connection", err)
 	}
 
-	select {
-	case <-proxyCtx.Done():
-		// Do not close the WebSocket connection as it should be already closed by our rendezvous party
-		return responder.Empty()
-	case <-ctx.Done():
-		// Connection should normally be closed by our rendezvous party, not by the worker
-		return controller.wsError(wsConn, websocket.StatusAbnormalClosure, "port forwarding RPC",
-			"unexpectedly disconnected worker", err)
+	for {
+		select {
+		case <-proxyCtx.Done():
+			// Do not close the WebSocket connection as it should be already closed by our rendezvous party
+			return responder.Empty()
+		case <-time.After(30 * time.Second):
+			pingCtx, pingCtxCancel := context.WithTimeout(ctx, 5*time.Second)
+
+			if err := wsConn.Ping(pingCtx); err != nil {
+				controller.logger.Warnf("port forwarding RPC: failed to ping the worker, "+
+					"connection might time out: %v", err)
+			}
+
+			pingCtxCancel()
+		case <-ctx.Done():
+			// Connection shouldn't be normally closed by the worker
+			return controller.wsErrorNoClose("watch RPC",
+				"worker unexpectedly disconnected", ctx.Err())
+		}
 	}
 }


### PR DESCRIPTION
We already have a similar logic in `(*Controller).rpcWatch()`:

https://github.com/cirruslabs/orchard/blob/987bd0c3f1f8a78a7a501a3c0935d39e45bafbb4/internal/controller/api_rpc_watch.go#L81-L89

So let's re-use it for port forwarding too, to prevent idle SSH connection termination by load balancer/proxy.