### PR TITLE
Try "tart ip --resolver=agent" first when using "--net-bridged"

### DIFF
--- a/internal/worker/vmmanager/vm.go
+++ b/internal/worker/vmmanager/vm.go
@@ -360,6 +360,16 @@ func (vm *VM) run(ctx context.Context) error {
 }
 
 func (vm *VM) IP(ctx context.Context) (string, error) {
+	// Bridged networking is problematic, so try with
+	// the agent resolver first using a small timeout
+	if vm.Resource.NetBridged != "" {
+		stdout, _, err := tart.Tart(ctx, vm.logger, "ip", "--wait", "5",
+			"--resolver", "agent", vm.id())
+		if err == nil {
+			return strings.TrimSpace(stdout), nil
+		}
+	}
+
 	args := []string{"ip", "--wait", "60"}
 
 	if vm.Resource.NetBridged != "" {


### PR DESCRIPTION
And fall back to `tart ip --resolver=arp` when that fails.

See https://github.com/cirruslabs/orchard/issues/218#issuecomment-2980414174.