### PR TITLE
orchard controller run: introduce "--pprof" command-line flag

### DIFF
--- a/internal/command/controller/run.go
+++ b/internal/command/controller/run.go
@@ -12,6 +12,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,6 +25,7 @@ var ErrRunFailed = errors.New("failed to run controller")
 
 var address string
 var addressSSH string
+var pprof bool
 var debug bool
 var noTLS bool
 var sshNoClientAuth bool
@@ -45,10 +49,9 @@ func newRunCommand() *cobra.Command {
 		"address to listen on")
 	cmd.Flags().StringVar(&addressSSH, "listen-ssh", "",
 		"address for the built-in SSH server to listen on (e.g. \":6122\")")
+	cmd.Flags().BoolVar(&pprof, "pprof", false,
+		"start pprof HTTP server on localhost:6060 for diagnostic purposes")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enable debug logging")
-
-	// flags for auto-init if necessary
-	// this simplifies the user experience to run the controller in serverless environments
 	cmd.Flags().StringVar(&controllerCertPath, "controller-cert", "",
 		"use the controller certificate from the specified path instead of the auto-generated one"+
 			" (requires --controller-key)")
@@ -93,6 +96,12 @@ func runController(cmd *cobra.Command, args []string) (err error) {
 			err = syncErr
 		}
 	}()
+
+	if pprof {
+		go func() {
+			log.Println(http.ListenAndServe("localhost:6060", nil))
+		}()
+	}
 
 	// Redirect standard's library package-global logger
 	// to our zap logger at debug level


### PR DESCRIPTION
Starts [pprof HTTP server](https://pkg.go.dev/net/http/pprof) on `localhost:6060` for diagnostic purposes