### PR TITLE
Fix websocket.(*Conn).timeoutLoop goroutine leak

### DIFF
--- a/internal/controller/api_rpc_portforward.go
+++ b/internal/controller/api_rpc_portforward.go
@@ -27,6 +27,13 @@ func (controller *Controller) rpcPortForward(ctx *gin.Context) responder.Respond
 	if err != nil {
 		return responder.Error(err)
 	}
+	defer func() {
+		// Ensure that we always close the accepted WebSocket connection,
+		// otherwise resource leak is possible[1]
+		//
+		// [1]: https://github.com/coder/websocket/issues/445#issuecomment-2053792044
+		_ = wsConn.CloseNow()
+	}()
 
 	// Respond with the established connection
 	proxyCtx, err := controller.connRendezvous.Respond(session, rendezvous.ResultWithErrorMessage[net.Conn]{

--- a/internal/controller/api_rpc_watch.go
+++ b/internal/controller/api_rpc_watch.go
@@ -37,6 +37,13 @@ func (controller *Controller) rpcWatch(ctx *gin.Context) responder.Responder {
 	if err != nil {
 		return responder.Error(err)
 	}
+	defer func() {
+		// Ensure that we always close the accepted WebSocket connection,
+		// otherwise resource leak is possible[1]
+		//
+		// [1]: https://github.com/coder/websocket/issues/445#issuecomment-2053792044
+		_ = wsConn.CloseNow()
+	}()
 
 	// Ensure that pongs will be processed by reading
 	// from the connection in the background

--- a/internal/controller/api_vms_portforward.go
+++ b/internal/controller/api_vms_portforward.go
@@ -102,6 +102,13 @@ func (controller *Controller) portForward(
 		if err != nil {
 			return responder.Error(err)
 		}
+		defer func() {
+			// Ensure that we always close the accepted WebSocket connection,
+			// otherwise resource leak is possible[1]
+			//
+			// [1]: https://github.com/coder/websocket/issues/445#issuecomment-2053792044
+			_ = wsConn.CloseNow()
+		}()
 
 		expectedMsgType := websocket.MessageBinary
 

--- a/internal/worker/rpcv2.go
+++ b/internal/worker/rpcv2.go
@@ -55,6 +55,13 @@ func (worker *Worker) handlePortForwardV2(ctx context.Context, portForward *v1.P
 
 		return
 	}
+	defer func() {
+		// Ensure that we always close the accepted WebSocket connection,
+		// otherwise resource leak is possible[1]
+		//
+		// [1]: https://github.com/coder/websocket/issues/445#issuecomment-2053792044
+		_ = netConn.Close()
+	}()
 
 	// Proxy bytes if the connection was established without errors
 	if errorMessage == "" {


### PR DESCRIPTION
See https://github.com/coder/websocket/issues/445#issuecomment-2053792044 for more details.

Also added `--listen-pprof` to `orchard worker run`.