### PR TITLE
Disable Prometheus metrics by default

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -61,6 +61,7 @@ type Controller struct {
 	maxWorkersPerLicense uint
 	experimentalRPCV2    bool
 	pingInterval         time.Duration
+	prometheusMetrics    bool
 
 	sshListenAddr   string
 	sshSigner       ssh.Signer
@@ -122,7 +123,7 @@ func New(opts ...Option) (*Controller, error) {
 
 	// Instantiate the scheduler
 	controller.scheduler, err = scheduler.NewScheduler(store, controller.workerNotifier,
-		controller.workerOfflineTimeout, controller.logger)
+		controller.workerOfflineTimeout, controller.prometheusMetrics, controller.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/option.go
+++ b/internal/controller/option.go
@@ -65,6 +65,12 @@ func WithPingInterval(pingInterval time.Duration) Option {
 	}
 }
 
+func WithPrometheusMetrics() Option {
+	return func(controller *Controller) {
+		controller.prometheusMetrics = true
+	}
+}
+
 func WithLogger(logger *zap.Logger) Option {
 	return func(controller *Controller) {
 		controller.logger = logger.Sugar()


### PR DESCRIPTION
Can be enabled back with `--deprecated-prometheus-metrics`.

Related to https://github.com/orgs/cirruslabs/projects/4?pane=issue&itemId=89520372.