### PR TITLE
orchard controller run: introduce --experimental-disable-db-compression

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -5,6 +5,12 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/cirruslabs/orchard/internal/controller/notifier"
 	"github.com/cirruslabs/orchard/internal/controller/rendezvous"
 	"github.com/cirruslabs/orchard/internal/controller/scheduler"
@@ -24,11 +30,6 @@ import (
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
-	"net"
-	"net/http"
-	"os"
-	"strings"
-	"time"
 )
 
 var (
@@ -60,6 +61,7 @@ type Controller struct {
 	workerOfflineTimeout time.Duration
 	maxWorkersPerLicense uint
 	experimentalRPCV2    bool
+	disableDBCompression bool
 	pingInterval         time.Duration
 	prometheusMetrics    bool
 
@@ -112,7 +114,8 @@ func New(opts ...Option) (*Controller, error) {
 	}
 
 	// Instantiate the database
-	store, err := badger.NewBadgerStore(controller.dataDir.DBPath(), controller.logger)
+	store, err := badger.NewBadgerStore(controller.dataDir.DBPath(), controller.disableDBCompression,
+		controller.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/option.go
+++ b/internal/controller/option.go
@@ -2,9 +2,10 @@ package controller
 
 import (
 	"crypto/tls"
+	"time"
+
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
-	"time"
 )
 
 type Option func(*Controller)
@@ -56,6 +57,12 @@ func WithWorkerOfflineTimeout(workerOfflineTimeout time.Duration) Option {
 func WithExperimentalRPCV2() Option {
 	return func(controller *Controller) {
 		controller.experimentalRPCV2 = true
+	}
+}
+
+func WithDisableDBCompression() Option {
+	return func(controller *Controller) {
+		controller.disableDBCompression = true
 	}
 }
 

--- a/internal/controller/store/badger/badger_store.go
+++ b/internal/controller/store/badger/badger_store.go
@@ -3,11 +3,13 @@ package badger
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/avast/retry-go/v4"
 	"github.com/cirruslabs/orchard/internal/controller/store"
 	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v3/options"
 	"go.uber.org/zap"
-	"time"
 )
 
 type Store struct {
@@ -20,10 +22,15 @@ type Transaction struct {
 	store.Transaction
 }
 
-func NewBadgerStore(dbPath string, logger *zap.SugaredLogger) (store.Store, error) {
+func NewBadgerStore(dbPath string, noCompression bool, logger *zap.SugaredLogger) (store.Store, error) {
 	opts := badger.DefaultOptions(dbPath).WithLogger(newBadgerLogger(logger))
 
 	opts.SyncWrites = true
+
+	if noCompression {
+		opts.Compression = options.None
+		opts.BlockCacheSize = 0
+	}
 
 	db, err := badger.Open(opts)
 	if err != nil {


### PR DESCRIPTION
`--experimental-disable-db-compression` might reduce RAM usage in certain scenarios.

And also report the number of workers and VMs processed in each scheduler iteration.