### PR TITLE
Support for prefixed Orchard Controller API URLs

### DIFF
--- a/internal/command/controller/run.go
+++ b/internal/command/controller/run.go
@@ -24,6 +24,7 @@ import (
 var ErrRunFailed = errors.New("failed to run controller")
 
 var address string
+var apiPrefix string
 var addressSSH string
 var addressPprof string
 var debug bool
@@ -50,6 +51,9 @@ func newRunCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&address, "listen", "l", fmt.Sprintf(":%s", port),
 		"address to listen on")
+	cmd.Flags().StringVar(&apiPrefix, "api-prefix", "",
+		"prefix to prepend to all Orchard Controller API endpoints; useful when exposing Orchard Controller "+
+			"behind an HTTP proxy together with other services")
 	cmd.Flags().StringVar(&addressSSH, "listen-ssh", "",
 		"address for the built-in SSH server to listen on (e.g. \":6122\")")
 	cmd.Flags().StringVar(&addressPprof, "listen-pprof", "",
@@ -142,6 +146,10 @@ func runController(cmd *cobra.Command, args []string) (err error) {
 		controller.WithDataDir(dataDir),
 		controller.WithWorkerOfflineTimeout(workerOfflineTimeout),
 		controller.WithLogger(logger),
+	}
+
+	if apiPrefix != "" {
+		controllerOpts = append(controllerOpts, controller.WithAPIPrefix(apiPrefix))
 	}
 
 	var controllerCert tls.Certificate

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
-	"fmt"
 	"net/http"
 	"path"
 	"strings"

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -5,7 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"net/http"
-	"path"
+	"net/url"
 	"strings"
 
 	"github.com/cirruslabs/orchard/api"
@@ -57,9 +57,14 @@ func (controller *Controller) initAPI() *gin.Engine {
 	// to check that the API is working
 	v1.GET("/", func(c *gin.Context) {
 		if controller.enableSwaggerDocs {
+			apiURL := &url.URL{
+				Path: "/",
+			}
+			apiURL = apiURL.JoinPath(controller.apiPrefix, "v1")
+
 			middleware.SwaggerUI(middleware.SwaggerUIOpts{
-				Path:    "/" + path.Join(controller.apiPrefix, "v1"),
-				SpecURL: "/" + path.Join(controller.apiPrefix, "v1", "openapi.yaml"),
+				Path:    apiURL.Path,
+				SpecURL: apiURL.JoinPath("openapi.yaml").Path,
 			}, nil).ServeHTTP(c.Writer, c.Request)
 		} else {
 			c.Status(http.StatusOK)

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/cirruslabs/orchard/api"
@@ -29,11 +30,12 @@ var ErrUnauthorized = errors.New("unauthorized")
 func (controller *Controller) initAPI() *gin.Engine {
 	ginEngine := gin.New()
 
-	group := ginEngine.Group("/")
+	var group *gin.RouterGroup
 
 	if controller.apiPrefix != "" {
-		fmt.Println("[+] registering api prefix", controller.apiPrefix)
 		group = ginEngine.Group(controller.apiPrefix)
+	} else {
+		group = ginEngine.Group("/")
 	}
 
 	group.Use(
@@ -57,8 +59,8 @@ func (controller *Controller) initAPI() *gin.Engine {
 	v1.GET("/", func(c *gin.Context) {
 		if controller.enableSwaggerDocs {
 			middleware.SwaggerUI(middleware.SwaggerUIOpts{
-				Path:    "/v1",
-				SpecURL: "/v1/openapi.yaml",
+				Path:    "/" + path.Join(controller.apiPrefix, "v1"),
+				SpecURL: "/" + path.Join(controller.apiPrefix, "v1", "openapi.yaml"),
 			}, nil).ServeHTTP(c.Writer, c.Request)
 		} else {
 			c.Status(http.StatusOK)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -46,6 +47,7 @@ const (
 type Controller struct {
 	dataDir              *DataDir
 	listenAddr           string
+	apiPrefix            string
 	tlsConfig            *tls.Config
 	listener             net.Listener
 	httpServer           *http.Server
@@ -262,11 +264,17 @@ func (controller *Controller) Run(ctx context.Context) error {
 func (controller *Controller) Address() string {
 	hostPort := strings.ReplaceAll(controller.listener.Addr().String(), "[::]", "127.0.0.1")
 
-	if controller.tlsConfig != nil {
-		return fmt.Sprintf("https://%s", hostPort)
+	url := url.URL{
+		Scheme: "http",
+		Host:   hostPort,
+		Path:   controller.apiPrefix,
 	}
 
-	return fmt.Sprintf("http://%s", hostPort)
+	if controller.tlsConfig != nil {
+		url.Scheme = "https"
+	}
+
+	return url.String()
 }
 
 func (controller *Controller) SSHAddress() (string, bool) {

--- a/internal/controller/option.go
+++ b/internal/controller/option.go
@@ -22,6 +22,12 @@ func WithListenAddr(listenAddr string) Option {
 	}
 }
 
+func WithAPIPrefix(apiPrefix string) Option {
+	return func(c *Controller) {
+		c.apiPrefix = apiPrefix
+	}
+}
+
 func WithTLSConfig(tlsConfig *tls.Config) Option {
 	return func(controller *Controller) {
 		controller.tlsConfig = tlsConfig

--- a/internal/netconstants/netconstants_test.go
+++ b/internal/netconstants/netconstants_test.go
@@ -1,0 +1,22 @@
+package netconstants_test
+
+import (
+	"testing"
+
+	"github.com/cirruslabs/orchard/internal/netconstants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAddress(t *testing.T) {
+	// Default port
+	url, err := netconstants.NormalizeAddress("subdomain.example.com/some/prefix")
+	require.NoError(t, err)
+	require.Equal(t, "subdomain.example.com:6120", url.Host)
+	require.Equal(t, "/some/prefix", url.Path)
+
+	// Custom port
+	url, err = netconstants.NormalizeAddress("subdomain.example.com:443/some/prefix")
+	require.NoError(t, err)
+	require.Equal(t, "subdomain.example.com:443", url.Host)
+	require.Equal(t, "/some/prefix", url.Path)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,6 +9,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/cirruslabs/orchard/internal/config"
 	"github.com/cirruslabs/orchard/internal/version"
 	"github.com/cirruslabs/orchard/rpc"
@@ -16,11 +22,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
-	"io"
-	"net"
-	"net/http"
-	"net/url"
-	"time"
 )
 
 var (
@@ -298,6 +299,7 @@ func (client *Client) formatPath(path string) *url.URL {
 		Scheme: client.baseURL.Scheme,
 		User:   client.baseURL.User,
 		Host:   client.baseURL.Host,
+		Path:   client.baseURL.Path,
 	}
 
 	return endpointURL.JoinPath("v1", path)


### PR DESCRIPTION
Orchard Controller now accepts `--api-prefix` to `orchard controller run`, which allows prefixing all of its API endpoints with the provided string.

For example, with `--api-prefix foo/bar`, `GET /v1/vms` becomes `GET /foo/bar/v1/vms`.

In addition, worker and things like `orchard context create` should now correctly handle these prefixes.