### PR TITLE
BadgerDB: set logging level to INFO

### DIFF
--- a/internal/controller/store/badger/badger_store.go
+++ b/internal/controller/store/badger/badger_store.go
@@ -23,7 +23,9 @@ type Transaction struct {
 }
 
 func NewBadgerStore(dbPath string, noCompression bool, logger *zap.SugaredLogger) (store.Store, error) {
-	opts := badger.DefaultOptions(dbPath).WithLogger(newBadgerLogger(logger))
+	opts := badger.DefaultOptions(dbPath).
+		WithLogger(newBadgerLogger(logger)).
+		WithLoggingLevel(badger.INFO)
 
 	opts.SyncWrites = true
 


### PR DESCRIPTION
The default `DEBUG` level produces too much useless noise in Orchard logs:

```
2025-11-11T19:10:34.198+0100	DEBUG	v3@v3.2103.5/db.go:815	writeRequests called. Writing to value log	{"component": "badger"}
2025-11-11T19:10:34.198+0100	DEBUG	v3@v3.2103.5/db.go:822	Sending updates to subscribers	{"component": "badger"}
2025-11-11T19:10:34.199+0100	DEBUG	v3@v3.2103.5/db.go:824	Writing to memtable	{"component": "badger"}
2025-11-11T19:10:34.199+0100	DEBUG	v3@v3.2103.5/db.go:852	2 entries written	{"component": "badger"}
2025-11-11T19:10:34.221+0100	DEBUG	v3@v3.2103.5/db.go:815	writeRequests called. Writing to value log	{"component": "badger"}
2025-11-11T19:10:34.221+0100	DEBUG	v3@v3.2103.5/db.go:822	Sending updates to subscribers	{"component": "badger"}
2025-11-11T19:10:34.221+0100	DEBUG	v3@v3.2103.5/db.go:824	Writing to memtable	{"component": "badger"}
2025-11-11T19:10:34.222+0100	DEBUG	v3@v3.2103.5/db.go:852	2 entries written	{"component": "badger"}
```