### PR TITLE
Fix Grafana k6 script to not consume all system's CPU

### DIFF
--- a/test/load/vm-lifecycle.js
+++ b/test/load/vm-lifecycle.js
@@ -8,7 +8,7 @@ import {expect} from 'https://jslib.k6.io/k6-testing/0.6.1/index.js';
 
 const BASE_URL = __ENV.BASE_URL || 'http://127.0.0.1:6120/v1';
 const WS_BASE_URL = __ENV.WS_BASE_URL || BASE_URL.replace(/^http/, 'ws');
-const WS_BYTES = __ENV.WS_BYTES || 64 * 1024;
+const WS_BYTES = Number(__ENV.WS_BYTES) || 64 * 1024;
 const SERVICE_ACCOUNT_NAME = __ENV.SERVICE_ACCOUNT_NAME;
 const SERVICE_ACCOUNT_TOKEN = __ENV.SERVICE_ACCOUNT_TOKEN;
 


### PR DESCRIPTION
This line seems to be the main culprit:

https://github.com/cirruslabs/orchard/blob/c02b55b7667c5f7e51f9d22094a737028e526afc/test/load/vm-lifecycle.js#L115

But also avoid useless reallocations and wasted GC cycles, and just compare a hash.

With this, even with 1,000 synthetic workers and 1,000 VUs (Virtual Users) (and [not 500](https://github.com/cirruslabs/orchard/pull/392) as previously tried) I get more sensible numbers on my machine, and `k6` does not consume 900% CPU or so.