### PR TITLE
echoserver: do not treat client errors as fatal

### DIFF
--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -196,7 +196,11 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 		// Use TCP echo server to partially emulate VM's TCP/IP stack,
 		// this way we get port-forwarding working when running in
 		// synthetic mode
-		echoServer, err := echoserver.New()
+		echoServerOpts := []echoserver.Option{
+			echoserver.WithLogger(logger.Sugar().With("component", "echoserver")),
+		}
+
+		echoServer, err := echoserver.New(echoServerOpts...)
 		if err != nil {
 			return err
 		}

--- a/internal/echoserver/option.go
+++ b/internal/echoserver/option.go
@@ -1,0 +1,11 @@
+package echoserver
+
+import "go.uber.org/zap"
+
+type Option func(echoServer *EchoServer)
+
+func WithLogger(logger *zap.SugaredLogger) Option {
+	return func(echoServer *EchoServer) {
+		echoServer.logger = logger
+	}
+}


### PR DESCRIPTION
And use `io.CopyBuffer()` to simplify code, but keep the multiple chunk semantics so that consumers will hopefully get more that one round-trip.