### PR TITLE
controller(listVMs): reduce allocations

### DIFF
--- a/internal/controller/api_vms.go
+++ b/internal/controller/api_vms.go
@@ -344,7 +344,9 @@ func (controller *Controller) listVMs(ctx *gin.Context) responder.Responder {
 		return responder.Code(http.StatusInternalServerError)
 	}
 
-	var vms []v1.VM
+	// Declare an empty, non-nil slice to
+	// return [] when no objects are found
+	vms := []v1.VM{}
 
 Outer:
 	for _, vm := range allVMs {


### PR DESCRIPTION
We don't need such a large slice since we'll normally only return a maximum of 2 VMs to each worker.

Before:

<img width="1507" height="722" alt="Screenshot 2026-02-05 at 21 43 42" src="https://github.com/user-attachments/assets/68fdc472-e2cd-4004-a9e1-be4ea2a3a12f" />

After:

<img width="1507" height="722" alt="Screenshot 2026-02-05 at 21 48 29" src="https://github.com/user-attachments/assets/668b167e-36ac-45a5-972a-fd0d32779a63" />
