### PR TITLE
controller(listVMs): avoid copy of each element when filtering

### DIFF
--- a/internal/controller/api_vms.go
+++ b/internal/controller/api_vms.go
@@ -349,6 +349,7 @@ func (controller *Controller) listVMs(ctx *gin.Context) responder.Responder {
 	vms := []v1.VM{}
 
 Outer:
+	// Use index-based loop to avoid per-iteration copies of v1.VM
 	for i := range allVMs {
 		for _, filter := range filters {
 			if !allVMs[i].Match(filter) {


### PR DESCRIPTION
As per [For statements with `range` clause](https://go.dev/ref/spec#For_range):

>The iteration variables may be declared by the "range" clause using a form of [short variable declaration](https://go.dev/ref/spec#Short_variable_declarations) (`:=`).
>
>In this case their [scope](https://go.dev/ref/spec#Declarations_and_scope) is the block of the "for" statement and each iteration **has its own new variables** [[Go 1.22](https://go.dev/ref/spec#Go_1.22)] (see also ["for" statements with a ForClause](https://go.dev/ref/spec#For_clause)).
>
>The variables have the types of their respective iteration values.

Before (note the `runtime.duffcopy`):

<img width="1507" height="782" alt="Screenshot 2026-02-06 at 16 52 05" src="https://github.com/user-attachments/assets/9b030710-75cf-4b97-ab92-a3e2c673f016" />

After:

<img width="1507" height="782" alt="Screenshot 2026-02-06 at 17 17 42" src="https://github.com/user-attachments/assets/415ba020-c54d-425b-9f09-eb91fe0cd7b9" />
