### PR TITLE
Instantiate new client for each spawned worker

### DIFF
--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -165,11 +165,6 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 			"in the bootstrap token", ErrRunFailed)
 	}
 
-	controllerClient, err := client.New(clientOpts...)
-	if err != nil {
-		return err
-	}
-
 	// Initialize the logger
 	logger, err := createLogger()
 	if err != nil {
@@ -224,6 +219,11 @@ func runWorker(cmd *cobra.Command, args []string) (err error) {
 
 			if workers > 1 {
 				workerOptsLocal = append(workerOptsLocal, worker.WithNameSuffix(fmt.Sprintf("-%d", i+1)))
+			}
+
+			controllerClient, err := client.New(clientOpts...)
+			if err != nil {
+				return err
 			}
 
 			workerInstance, err := worker.New(controllerClient, workerOptsLocal...)


### PR DESCRIPTION
This way we get HTTP connection re-use and avoid wasting cycles on TLS handshakes, both on a controller, and on workers.

But not for WebSockets, unfortunately.