### PR TITLE
Grafana k6 load script: handle exceptions and provide more checks

### DIFF
--- a/test/load/vm-lifecycle.js
+++ b/test/load/vm-lifecycle.js
@@ -110,7 +110,7 @@ async function portForward(vmName) {
 
     check(result, {
         'WebSocket closed normally (1000)': (r) => r.code === 1000,
-        'WebSocket had no errors': (r) => r.error,
+        'WebSocket had no errors': (r) => !r.error,
     });
 
     check(numReceivedBytes, {


### PR DESCRIPTION
This avoids spam and provides a nice result at the end, e.g.:

```
  █ TOTAL RESULTS 

    checks_total.......: 187551 1247.891121/s
    checks_succeeded...: 98.14% 184080 out of 187551
    checks_failed......: 1.85%  3471 out of 187551

    ✓ VM creation succeeded
    ✗ WebSocket closed normally (1000)
      ↳  95% — ✓ 21792 / ✗ 967
    ✗ WebSocket had no errors
      ↳  96% — ✓ 21792 / ✗ 836
    ✗ WebSocket received exactly WS_BYTES back
      ↳  96% — ✓ 43584 / ✗ 1668
    ✓ VM deletion succeeded

    HTTP
    http_req_duration..............: avg=1.11s  min=722.2µs med=757.15ms max=4.58s p(90)=2.63s  p(95)=2.85s 
      { expected_response:true }...: avg=1.11s  min=722.2µs med=757.15ms max=4.58s p(90)=2.63s  p(95)=2.85s 
    http_req_failed................: 0.00%  0 out of 48456
    http_reqs......................: 48456  322.407303/s

    EXECUTION
    iteration_duration.............: avg=30.19s min=1.07s   med=29.92s   max=1m1s  p(90)=51.94s p(95)=55.22s
    iterations.....................: 21723  144.53636/s
    vus............................: 5010   min=0          max=9960 
    vus_max........................: 10000  min=4410       max=10000

    NETWORK
    data_received..................: 1.5 GB 10 MB/s
    data_sent......................: 1.5 GB 10 MB/s

    WEBSOCKET
    ws_connecting..................: avg=28.72s min=1.07s   med=29.94s   max=1m0s  p(90)=50.14s p(95)=53.45s
    ws_msgs_received...............: 178008 1184.395725/s
    ws_msgs_sent...................: 43584  289.990918/s
    ws_session_duration............: avg=28.14s min=1.07s   med=27.11s   max=58.9s p(90)=50.42s p(95)=53.8s 
    ws_sessions....................: 23548  156.679197/s
```