### PR TITLE
Enable Gin's context fallback

### DIFF
--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -30,6 +30,10 @@ var ErrUnauthorized = errors.New("unauthorized")
 func (controller *Controller) initAPI() *gin.Engine {
 	ginEngine := gin.New()
 
+	// Enable Gin's context fallback to make (*gin.Context).Done() work
+	// and to avoid calling the (*gin.Context).Request.Context().Done()
+	ginEngine.ContextWithFallback = true
+
 	var group *gin.RouterGroup
 
 	if controller.apiPrefix != "" {


### PR DESCRIPTION
An interesting thing that Codex highligted while reviewing https://github.com/cirruslabs/orchard/pull/408 is that if we add the following quick-and-dirty endpoint to Orchard Controller:


```golang
v1.GET("/hang", func(c *gin.Context) {
	for {
		select {
		case <-c.Done():
			controller.logger.Info("the client had left")

			return
		case <-time.After(1 * time.Second):
			controller.logger.Info("we still think that the client is connected")
		}
	}
})
```

And simply call it with cURL and then press <kbd>Ctrl + C</kbd>, we'll never get the `the client had left` message in logs, because we're supposed to use `c.Request.Context()` instead of just `c`.

But there's an option that makes `c` work as it should work in the first place.