### PR TITLE
[codex] Preserve worker last_seen on sparse updates

### DIFF
--- a/internal/controller/api_workers.go
+++ b/internal/controller/api_workers.go
@@ -104,7 +104,9 @@ func (controller *Controller) updateWorker(ctx *gin.Context) responder.Responder
 			return responder.Error(err)
 		}
 
-		dbWorker.LastSeen = userWorker.LastSeen
+		if !userWorker.LastSeen.IsZero() {
+			dbWorker.LastSeen = userWorker.LastSeen
+		}
 		dbWorker.SchedulingPaused = userWorker.SchedulingPaused
 
 		if err := txn.SetWorker(*dbWorker); err != nil {

--- a/internal/tests/integration_test.go
+++ b/internal/tests/integration_test.go
@@ -174,6 +174,41 @@ func TestPortForwarding(t *testing.T) {
 	require.Contains(t, string(unameOutput), cases.Title(language.English).String(runtime.GOOS))
 }
 
+func TestSparseWorkerUpdatePreservesLastSeen(t *testing.T) {
+	ctx := context.Background()
+
+	devClient, _, _ := devcontroller.StartIntegrationTestEnvironmentWithAdditionalOpts(
+		t,
+		false,
+		nil,
+		true,
+		nil,
+	)
+
+	lastSeen := time.Now().Add(-time.Minute).UTC().Truncate(time.Microsecond)
+	_, err := devClient.Workers().Create(ctx, v1.Worker{
+		Meta: v1.Meta{
+			Name: "sparse-update-worker",
+		},
+		LastSeen:  lastSeen,
+		MachineID: "sparse-update-machine",
+	})
+	require.NoError(t, err)
+
+	_, err = devClient.Workers().Update(ctx, v1.Worker{
+		Meta: v1.Meta{
+			Name: "sparse-update-worker",
+		},
+		SchedulingPaused: true,
+	})
+	require.NoError(t, err)
+
+	worker, err := devClient.Workers().Get(ctx, "sparse-update-worker")
+	require.NoError(t, err)
+	require.Equal(t, lastSeen, worker.LastSeen)
+	require.True(t, worker.SchedulingPaused)
+}
+
 // TestSchedulerHealthCheckingNonExistentWorker ensures that scheduler
 // will eventually fail VMs that are scheduled on a worker that was
 // deleted from the API.


### PR DESCRIPTION
## Summary

Preserve `worker.last_seen` when sparse worker updates omit that field.

## Why

A sparse update used only to change fields such as `scheduling_paused` could unintentionally overwrite `last_seen` with the zero time, making a healthy worker appear stale.

## What changed

- only update `LastSeen` when the incoming worker payload provides a non-zero value
- add an integration regression test covering sparse worker updates

## Validation

- `go test ./internal/controller/...`
- `git diff --check origin/main...HEAD`
