### PR TITLE
Close accepted VNC connections

### DIFF
--- a/internal/command/vnc/vm.go
+++ b/internal/command/vnc/vm.go
@@ -66,6 +66,8 @@ func runVNCVM(cmd *cobra.Command, args []string) (err error) {
 			}
 
 			go func() {
+				defer conn.Close()
+
 				wsConn, err := client.VMs().PortForward(cmd.Context(), name, vncPort, wait)
 				if err != nil {
 					fmt.Printf("failed to forward port: %v\n", err)

--- a/internal/command/vnc/worker.go
+++ b/internal/command/vnc/worker.go
@@ -56,6 +56,8 @@ func runVNCWorker(cmd *cobra.Command, args []string) (err error) {
 			}
 
 			go func() {
+				defer conn.Close()
+
 				wsConn, err := client.Workers().PortForward(cmd.Context(), name, vncPort)
 				if err != nil {
 					fmt.Printf("failed to forward port: %v\n", err)


### PR DESCRIPTION
## Summary
- close accepted local TCP connections in VNC VM forwarding
- close accepted local TCP connections in VNC worker forwarding
- match the existing port-forward cleanup pattern to avoid leaking descriptors on setup failures or disconnects

## Testing
- `go test ./internal/command/vnc`
- `go test -run '^$' ./...`